### PR TITLE
Basic user account flows

### DIFF
--- a/app/layouts/base.njk
+++ b/app/layouts/base.njk
@@ -51,9 +51,12 @@
     serviceUrl: "/logs"  if data.account else "/",
     containerClasses: "govuk-width-container",
     navigation: [{
+      href: "/account/",
+      text: "Your account"
+    }, {
       href: "/account/sign-out",
       text: "Sign out"
-    }] if data.account
+    }] if data.account.token
   }) }}
 {% endblock %}
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -10,9 +10,17 @@ const router = express.Router()
  * Account
  */
 router.get('/account/sign-out', (req, res) => {
-  delete req.session.data.account
+  delete req.session.data.account.token
 
-  res.redirect('/')
+  res.redirect('/account/sign-in')
+})
+
+router.all('/account/:view?', (req, res) => {
+  const view = req.params.view ? req.params.view : 'index'
+  const { referrer, success } = req.query
+  const { account } = req.session.data
+
+  res.render(`account/${view}`, { account, referrer, success })
 })
 
 /**

--- a/app/views/account/check-your-email.njk
+++ b/app/views/account/check-your-email.njk
@@ -1,0 +1,14 @@
+{% extends "base.njk" %}
+
+{% set title = "Check your email" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title) }}
+
+      <p><a class="govuk-link--no-underline govuk-link--text-colour" href="/account/reset-password">If this email address exists in our system, we will have sent a link to reset your password to <strong>{{ data.account.email or "name@example.com" }}</strong>.</a></p>
+      <p>If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or <a href="/account/request-password-reset">try again</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/account/create-account.njk
+++ b/app/views/account/create-account.njk
@@ -1,0 +1,53 @@
+{% extends "form.njk" %}
+
+{% set title = "Create a CORE account" %}
+{% set formAction = "/logs" %}
+
+{% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title) }}
+
+      <p>You have been invited to create a CORE account with the email address <strong>jane.doe@walford.gov.uk</strong>.</p>
+
+      {{ govukInput(decorate({
+        type: "hidden",
+        value: "Jane Doe"
+      }, ["account", "name"])) }}
+
+      {{ govukInput(decorate({
+        type: "hidden",
+        value: "jane.doe@walford.gov.uk"
+      }, ["account", "email"])) }}
+
+      {{ govukInput({
+        label: {
+          text: "Create a password"
+        },
+        hint: {
+          text: "Your password must be at least 8 characters and hard to guess."
+        },
+        type: "password",
+        autocomplete: "new-password",
+        spellcheck: false
+      }) }}
+
+      {{ govukCheckboxes({
+        name: "agreed-terms",
+        items: [{
+          value: "yes",
+          html: "I agree to the <a href=\"#\">terms and conditions</a>"
+        }]
+      }) }}
+
+      {{ govukInput(decorate({
+        type: "hidden",
+        value: "true"
+      }, ["account", "token"])) }}
+
+      {{ govukButton({
+        text: "Create account"
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/account/index.njk
+++ b/app/views/account/index.njk
@@ -1,0 +1,59 @@
+{% extends "base.njk" %}
+
+{% set title = "Your account" %}
+{% set referrer = "/account" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title) }}
+
+      <h2 class="govuk-heading-m">Personal details</h2>
+      {{ govukSummaryList({
+        rows: [{
+          key: {
+            text: "Name"
+          },
+          value: {
+            text: account.name
+          },
+          actions: {
+            items: [{
+              href: "/account/personal-details?referrer=" + referrer,
+              text: "Change",
+              visuallyHiddenText: "name"
+            }]
+          }
+        }, {
+          key: {
+            text: "Email address"
+          },
+          value: {
+            text: account.email
+          },
+          actions: {
+            items: [{
+              href: "/account/personal-details?referrer=" + referrer,
+              text: "Change",
+              visuallyHiddenText: "email address"
+            }]
+          }
+        }, {
+          key: {
+            text: "Password"
+          },
+          value: {
+            html: "••••••••"
+          },
+          actions: {
+            items: [{
+              href: "/account/password?referrer=" + referrer,
+              text: "Change",
+              visuallyHiddenText: "password"
+            }]
+          }
+        }]
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/account/password.njk
+++ b/app/views/account/password.njk
@@ -1,0 +1,38 @@
+{% extends "form.njk" %}
+
+{% set title = "Change your password" %}
+{% set backLink = "/account" %}
+{% set formAction = "/account" %}
+
+{% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title) }}
+
+      {{ govukInput({
+        label: {
+          text: "Current password"
+        },
+        type: "password",
+        autocomplete: "current-password",
+        spellcheck: false
+      }) }}
+
+      {{ govukInput({
+        label: {
+          text: "New password"
+        },
+        hint: {
+          text: "Your password must be at least 8 characters and hard to guess."
+        },
+        type: "password",
+        autocomplete: "new-password",
+        spellcheck: false
+      }) }}
+
+      {{ govukButton({
+        text: "Change password"
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/account/personal-details.njk
+++ b/app/views/account/personal-details.njk
@@ -1,0 +1,33 @@
+{% extends "form.njk" %}
+
+{% set title = "Change your personal details" %}
+{% set backLink = "/account" %}
+{% set formAction = "/account" %}
+
+{% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title) }}
+
+      {{ govukInput(decorate({
+        label: {
+          text: "Name"
+        },
+        autocomplete: "name",
+        spellcheck: false
+      }, ["account", "name"])) }}
+
+      {{ govukInput(decorate({
+        label: {
+          text: "Email address"
+        },
+        autocomplete: "email",
+        spellcheck: false
+      }, ["account", "email"])) }}
+
+      {{ govukButton({
+        text: "Save changes"
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/account/request-password-reset.njk
+++ b/app/views/account/request-password-reset.njk
@@ -1,0 +1,27 @@
+{% extends "form.njk" %}
+
+{% set title = "Reset password" %}
+{% set backLink = "/account/sign-in" %}
+{% set formAction = "/account/check-your-email" %}
+
+{% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title) }}
+
+      <p>Enter the email address you used to create your CORE account. We will email you a link so you can reset your password.</p>
+
+      {{ govukInput(decorate({
+        label: {
+          text: "Email address"
+        },
+        autocomplete: "email",
+        spellcheck: false
+      }, ["account", "email"])) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/account/reset-password.njk
+++ b/app/views/account/reset-password.njk
@@ -1,0 +1,28 @@
+{% extends "form.njk" %}
+
+{% set title = "Reset your password" %}
+{% set formAction = "/account/sign-in?success=password-reset" %}
+
+{% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title) }}
+
+      {{ govukInput({
+        label: {
+          text: "New password"
+        },
+        hint: {
+          text: "Your password must be at least 8 characters and hard to guess."
+        },
+        type: "password",
+        autocomplete: "new-password",
+        spellcheck: false
+      }) }}
+
+      {{ govukButton({
+        text: "Reset password"
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/account/sign-in.njk
+++ b/app/views/account/sign-in.njk
@@ -1,17 +1,20 @@
 {% extends "form.njk" %}
 
-{% set title = "Sign in" %}
+{% set title = "Sign in to your CORE account" %}
 {% set formAction = "/logs" %}
 
 {% block form %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">{{ title }}</h1>
+      {{ govukNotificationBanner({
+        html: "Your password has been reset. Sign in with your new password to continue.",
+        type: "success"
+      }) if success == "password-reset" }}
+
+      {{ macro.heading(title) }}
 
       {{ govukInput(decorate({
-        classes: "govuk-!-width-two-thirds",
         label: {
-          classes: "govuk-label--m",
           text: "Email address"
         },
         autocomplete: "email",
@@ -19,18 +22,24 @@
       }, ["account", "email"])) }}
 
       {{ govukInput({
-        classes: "govuk-!-width-two-thirds",
         label: {
-          classes: "govuk-label--m",
           text: "Password"
         },
         type: "password",
+        autocomplete: "current-password",
         spellcheck: false
       }) }}
+
+      {{ govukInput(decorate({
+        type: "hidden",
+        value: "true"
+      }, ["account", "token"])) }}
 
       {{ govukButton({
         text: "Sign in"
       }) }}
+
+      <p>You can <a href="/account/request-password-reset">reset your password</a> if you’ve forgotten it.</p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Basic user account flows and pages, that are available to all users. The next PR will add the first level of permissions which will allow some users to add and manage users.

## Sign in

![sign-in](https://user-images.githubusercontent.com/813383/138724317-6f44db21-2616-45cf-8ec3-e6086fca396e.png)

* Say ‘CORE account’, to distinguish this account from others used across GOV.UK.
* Provide an opportunity to reset password if you’ve forgotten it.

## Reset password flow

If you have forgotten your password, you can request a link to reset it.

![request-password-reset](https://user-images.githubusercontent.com/813383/138724294-27372258-9b20-469f-a368-6544ab76d8e0.png)

* When requesting a password reset, don’t give any indication that the email exists on our systems at all.

![check-your-email](https://user-images.githubusercontent.com/813383/138724235-039aaace-1afa-411c-a7a2-cacb58475036.png)

* If email exists on CORE, an email is sent to the user with a link to a page where they can reset their password. Email not shown – would it be helpful to include it in the prototype?

![reset-password](https://user-images.githubusercontent.com/813383/138724307-58884c90-e8cf-4539-b2f3-889b3590a61b.png)

* For passwords, stipulating that it be longer than 8 characters long. Do we need any other rules?

![password-reset](https://user-images.githubusercontent.com/813383/138724256-5a58a443-88d5-4b84-9a4f-5fae7b195fe6.png)

* Once your password has been reset, you are returned to the sign in page, where a success notification is shown.

## Signed in

![account](https://user-images.githubusercontent.com/813383/138724210-edd1c3cd-e93c-4106-ad4b-ed02eef249cd.png)

* All signed in users see a ‘Your account link’ in the navigation.
* From this page they can update information help about them.
* ⚠️Once permission levels are introduced, some users won’t be able to change their email address. All users can change their password, however.

![personal-details](https://user-images.githubusercontent.com/813383/138724283-734390de-f06c-438b-a68f-f49a4ba90036.png)

![change-password](https://user-images.githubusercontent.com/813383/138724221-80aa25a8-54d5-4bc5-88a1-b57c6c654e35.png)

## Create an account

![create-account](https://user-images.githubusercontent.com/813383/138724251-219c42a5-c3a4-4ef6-be8c-e0d71cd8bfc3.png)

* Users have to be invited to the service before they can create an account.
* This functionality has not been added yet.
* Invited users need to choose a password.
* Have included a checkbox for terms and conditions… is this needed? 