### PR TITLE
Add data sharing agreement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/app/filters.js
+++ b/app/filters.js
@@ -68,6 +68,12 @@ export default (env) => {
     return filtered
   }
 
+  filters.ordinal = (number) => {
+    const s = ['th', 'st', 'nd', 'rd']
+    const v = number % 100
+    return number + (s[(v - 20) % 10] || s[v] || s[0])
+  }
+
   filters.optionItems = (array, text, value, hint = false) => {
     text = text || 'name'
     value = value || 'id'

--- a/app/layouts/content.njk
+++ b/app/layouts/content.njk
@@ -1,0 +1,15 @@
+{% extends "layouts/base.njk" %}
+
+{% import "macros.njk" as macro %}
+
+{% set headingSize = headingSize or "xl" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title, caption, headingSize) }}
+
+      {% block body %}{{ markdown | govukMarkdown | safe }}{% endblock %}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/organisations/data-sharing-agreement.njk
+++ b/app/views/organisations/data-sharing-agreement.njk
@@ -1,0 +1,173 @@
+{% extends "layouts/content.njk" %}
+
+{% set title = "Data sharing agreement" %}
+{% set signedDSA = organisation.signedDSA | govukDate %}
+{% set signedDSADay = signedDSA.split(" ")[0] %}
+{% set signedDSAMonth = signedDSA.split(" ")[1] %}
+{% set signedDSAYear = signedDSA.split(" ")[2] %}
+
+{% set markdown %}
+## {{ organisation.name }} and Department for Levelling Up, Housing and Communities
+
+This agreement is made the {{ signedDSADay | ordinal }} day of {{ signedDSAMonth }} {{ signedDSAYear }}.
+
+**between**
+
+1. {{ organisation.name }} of {{ organisation.address }} (“CORE Data Provider”)
+
+and
+
+2. The Department for Levelling Up, Housing and Communities of 2 Marsham Street, London, SW1P 4DF (“DLUHC”)
+
+### 1. Background
+1.1. The Department for Levelling Up, Housing and Communities (DLUHC) collect data on social housing lettings and sales via CORE (COntinuous REcording of social housing lettings and sales) for statistical purposes. They are the data controller for all data within the CORE system.
+
+1.2. The purpose of this Agreement is to describe the duties of CORE data providers to DLUHC and to formalise the arrangement established to share the data between DLUHC and data providers. This agreement covers all data in the CORE system. This agreement does not cover data providers’ own versions of these data.
+
+1.3. Data providers and DLUHC will each be responsible for compliance with the Data Protection legislation including the Data Protection Act 2018 and the EU General Data Protection Regulation (GDPR).
+
+1.4. DLUHC shall only collect data from and share data with CORE data providers that have signed this data sharing agreement.
+
+1.5. There are occasions when DLUHC may instruct a third party to carry out analysis on the CORE dataset on their behalf. This third party will be a data processor for DLUHC and work under a contract ensuring data protection compliance.
+
+**It is now agreed** as follows:
+
+### 2. Definitions and interpretation
+2.1. In this Agreement the following words and phrases shall have the following meanings, unless expressly stated to the contrary:
+
+* “Act” means the Data Protection Act 2018;
+* “Authorised Representatives” means the nominated lead officer representing each of the
+parties with delegated authority to handle the day-to-day matters arising from this Agreement;
+* “Data Subject” means social housing lettings tenants and participants in discounted sales where their data is reported via the CORE system.
+* “Data Controller” has the meaning in Article 4(7) of the GDPR and section 5(2) of the Act.
+* “Data Processor” has the meaning in Article 4(8) of the GDPR.
+* “Data Protection Legislation” means the Data Protection Act 2018 and all applicable laws and regulations relating to the processing of personal data and privacy, including where applicable the guidance and codes of practice issued by the Information Commissioner; it includes the General Data Protection Regulation (GDPR).
+* “Data” means the data supplied by the CORE data providers via the CORE system and the data that is calculated or derived via the CORE system based on that initial data;
+* “GDPR” means the General Data Protection Regulation.
+* “Parties” means the parties to this Agreement, namely DLUHC and the CORE data providers. CORE data providers include social housing providers and managing organisations that provide data on behalf of the social housing providers.
+* “Personal Data” has the meaning in Article 4(1) of the GDPR. “Processing” has the meaning in Article 4(2) of the GDPR.
+* “Request for Information” means a request for information or a request under the Freedom of Information Act 2000.
+* “Special category personal data” has the meaning in Article 9(1) of the GDPR. In this Agreement:
+  * A. The masculine includes the feminine and neuter;
+  * B. Person means a natural person;
+  * C. The singular includes the plural and vice versa;
+  * D. A reference to any statute, enactment, order, regulation or other similar instrument
+shall be construed as a reference to the statute, enactment, order, regulation or instrument as amended by any subsequent statute, enactment, order, regulation or instrument or as contained in any subsequent re-enactment.
+
+2.2. Headings are included in this Agreement for ease of reference only and shall not affect the interpretation or construction of this Agreement.
+
+2.3. References in this Agreement to Clauses, Paragraphs and Annexes are, unless otherwise provided, references to the Clauses, Paragraphs and Annexes of this Agreement.
+
+2.4. In the event and to the extent only of any conflict or inconsistency between the provisions of this Agreement and the provisions of any document referred to or referenced herein, the provisions of this Agreement shall prevail.
+
+### 3. Commencement and term
+3.1. This Agreement shall commence upon signature by the Parties and shall continue in effect whilst the CORE data collection remains live, in accordance with the requirements of this Agreement unless otherwise subject to earlier termination in accordance with Clause 15.
+
+3.2. The Parties may, by mutual consent in writing, agree to amend this agreement.
+
+### 4. Purpose and scope of data collection via CORE
+4.1. CORE (COntinuous Recording of social housing lettings and sales) is a national information source funded by the Department for Levelling Up, Housing and Communities that records information on the characteristics of Private Registered Providers’ and Local Authorities’ new social housing tenants and the homes they rent and buy.
+
+4.2. The CORE dataset includes information on the letting or sale, type of tenancy or sale, rents and charges, demographic information about the tenant/buyer and other information related to the tenants/buyers themselves (e.g. source of referral, route into housing, whether they are on benefits, income).
+
+4.3. The data in the CORE dataset is considered personal data because individuals could be easily identified. The dataset does not contain direct personal identifiers but when taken as a whole the data allows social housing tenants to be identified. This is because the dataset contains information such as UPRN (Unique Property Reference Number), which allows properties to be uniquely identified or full postcode data.
+
+4.4. The dataset also contains information which is very sensitive, and which in some cases is “special category” personal data for the purposes of the GDPR, and if disclosed could cause considerable distress to the data subject, for example it indicates whether the social housing tenant has been in prison or probation or referred by a mental health institution; or whether anyone in the household has suffered from domestic abuse or hate crime.
+
+### 5. Roles and responsibilities
+5.1. DLUHC shall be the ‘Data controller’ for all personal data held within the CORE database.
+
+5.2. CORE data providers are data controllers for personal data that they hold within their own systems. It is recognised that while much of the CORE data will be replicated in data collections held by CORE data providers, each organisation accepts full data controller responsibility for the data it holds.
+
+5.3. CORE data providers need to submit information for the tenancy, the tenants and the property each time there is a new social housing letting or sale. The data collection covers general needs and supported housing lettings. Since April 2012, local authorities and private registered providers report their affordable rent lettings as well as their social rent lettings and, from April 2017, rent-to-buy lettings are also included.
+
+5.4. In order to be compliant with the data protection legislation all data subjects (social housing tenants and buyers) from the CORE dataset need to be informed of how their data will be processed and used.
+
+5.5. DLUHC has set the information that needs to be provided to new CORE data subjects in the privacy notice in Annex 1 of this agreement. CORE data providers must either share the DLUHC privacy notice with tenants or if using their own privacy notice, state within that they share the data with DLUHC and provide a link to the DLUHC privacy notice.
+
+### 6. Legal basis for data sharing
+6.1. CORE provides DLUHC with an essential evidence base for monitoring and developing government policy, in particular to assess who is accessing social housing and their associated tenancy and property details. It is necessary therefore that the personal data that forms the CORE data is processed for that purpose. The legal basis for processing this personal data is s(8)(d) of the Data Protection Act 2018 which states:
+
+> In Article 6(1) of the GDPR (lawfulness of processing), the reference in point (e) to processing of personal data that is necessary for the performance of a task carried out in the public interest or in the exercise of the controller’s official authority includes processing of personal data that is necessary for— (d) the exercise of a function of the Crown, a Minister of the Crown or a government department.
+
+6.2. In addition to the previous paragraph, processing of ‘special category’ personal data is prohibited unless a condition at Article 9 of the GDPR is satisfied. In this case the relevant condition is Article 9(2)(g) “the processing is necessary for reasons of substantial public interest”. This requires the processing to have a basis in law. In this case section 10(3) of the Act provides that the requirement is met by the processing being necessary by virtue of the conditions at paragraphs 5 and 6 of Schedule 1, Part 2.
+
+6.3. Article 10 of the GDPR requires that the processing of any criminal convictions and offences data shall be carried out only under control of official authority or when the processing is authorised in law. In this case section 10(5) of the Act provides that this requirement is met by the processing being necessary by virtue of the same condition at Schedule 1, Part 2.
+
+6.4. The data submitted to CORE and processed is made available to the CORE data providers registered in the system for further use to encourage use of available evidence to assess housing requirements. CORE data providers can only access CORE personal data that has been submitted by their organisation.
+
+### 7. Use of data
+7.1. The Parties understand that the CORE data submitted via the CORE data collection and accessed via the same system is being used for research and analytical purposes only and cannot be used for any other purpose, such as making decisions in relation to specific individuals.
+
+### 8. SECURITY OF DATA TRANSFER
+8.1. The security of the CORE data collection system is compliant with Government security standards (https://core.communities.gov.uk/public/index.html).
+
+8.2. All parts of the CORE website where an individual’s letting/sale data is submitted or downloaded are only accessible via login and passwords. The CORE system has hierarchies in place to ensure that data providers and users can only submit, view or download data for the organisations they are associated with.
+
+8.3. Data providers will be able to access the CORE personal data they submitted right after it is validated by the system; but can only access processed data from DLUHC after DLUHC has published the data. DLUHC will make the processed data available to data providers as soon as possible via the system.
+
+8.4.CORE team members in DLUHC and third-party data processors as developers/maintenance contractors have access to all parts of the website, including data. The handling of CORE data by contractors is covered in the contracts with these organisations. All CORE staff that have access to the data have had training on how to handle personal data.
+
+8.5. All work carried out by DLUHC will follow appropriate security measures and procedures to ensure the protection of the data.
+
+### 9. Protection of personal data
+9.1. CORE data providers and DLUHC agree that they shall:
+
+* A. Implement appropriate technical and organisational measures to protect the Personal Data against unauthorised or unlawful Processing and against accidental loss, destruction, damage, alteration or disclosure. These measures shall ensure a level of security appropriate to the harm which might result from any unauthorised or unlawful Processing, accidental loss, destruction or damage to the Personal Data and having regard to the nature of the Personal Data which is to be protected;
+* B. Take reasonable steps to ensure the reliability of any personnel who have access to the Personal Data. DLUHC and Data providers will ensure such personnel will be a limited number of analysts assigned to the data collection.
+
+9.2. The data providers and DLUHC shall comply at all times with the Data Protection Legislation and shall ensure that they each perform their obligations under this agreement in full compliance with the Data Protection Legislation and any other applicable law, in particular the Human Rights Act 1998 and the common law duty of confidentiality.
+
+9.3. CORE data providers should limit access to CORE to a small number of individuals who can be named on request. CORE access is limited to registered users only via password, but it is the responsibility of the CORE data providers to ensure that all individuals granted access to the datasets should be briefed on the legal requirements around handling and storing the Data from CORE.
+
+### 10. Freedom of information
+10.1. DLUHC acknowledges that CORE data providers that are or act on behalf of local authorities may be subject to the requirements of the FOIA and the Environmental Information Regulations and shall assist and cooperate with them to enable them to comply with their Information disclosure requirements.
+
+### 11. Loss or unauthorised release
+11.1. CORE data providers will report to DLUHC any loss or unauthorised release of the Data as soon as possible and no later than 24 hours after the loss or unauthorised release is identified. DLUHC will report to CORE data providers any loss or unauthorised release of the Data as soon as possible and no later than 24 hours after the loss or unauthorised release is identified.
+
+11.2. CORE data providers and DLUHC acknowledge that any loss or unauthorised release of the Data can be treated as valid grounds for immediately terminating this agreement by DLUHC.
+
+### 12. Authorised representatives
+12.1. CORE data providers and DLUHC will each appoint an Authorised Representative to be the primary point of contact in all day-to-day matters relating to this Agreement:
+
+12.2. For {{ organisation.name }}:
+
+* Name: {{ data.account.name }}<br>
+* Postal Address: {{ organisation.address }}<br>
+* E-mail address: {{ data.account.email }}<br>
+* Telephone number: {{ organisation.tel }}
+
+12.3. For DLUHC:
+
+* Name: Rachel Worledge<br>
+* Postal Address: South-west section, 4th Floor, Fry Building, 2 Marsham Street, London, SW1P 4DF<br>
+* E-mail address: rachel.worledge@levellingup.gov.uk<br>
+
+### 13. Products and publications
+13.1. The Data potentially allows for persons to be identified, although the risk of this happening should be minimised by the steps taken in clause 9. CORE data providers should agree to carry out a thorough check of the Data and ensure that all steps are taken within its powers to minimise the risk that any outputs lead to identification of a person by a third party.
+
+### 14. Dispute resolution
+14.1. Any disputes arising concerning this Agreement will be resolved initially by discussions between the Authorised Representatives of the CORE data providers and DLUHC.
+
+14.2. If the dispute cannot be resolved amicably between the Authorised Representatives then the matter will be escalated to: for the CORE data providers: the Chief Executive; and for DLUHC: the Deputy Director of the Data, Analytics and Statistics Division.
+
+### 15. Termination
+15.1. Any Party may terminate this Agreement upon one month’s written notice to the other.
+
+15.2. Any Party may terminate this Agreement with immediate effect in the event of a
+material breach of its obligations by the other Party to this Agreement.
+
+### 16. Statutory compliance
+16.1. The Parties shall comply with all relevant legislation, regulations, orders, statutory instruments and any amendments or re-enactments thereof from the commencement of this agreement.
+
+As witness of which the parties have set their hands on the day and year first above written
+signed for and on behalf of {{ "Data protection officer" }} for {{ organisation.name }}, by:
+
+* Name: {{ data.account.name }}
+* Title: {{ "Data protection officer" }}
+
+SIGNED for and on behalf of the deputy director of the data, analytics & statistics in the Department for Levelling Up, Housing and Communities, by:
+
+* Name: Sandra Tudor
+* Title: Deputy Director{% endset %}

--- a/app/views/organisations/organisation.njk
+++ b/app/views/organisations/organisation.njk
@@ -113,6 +113,17 @@
             href: "#",
             visuallyHiddenText: "child organisations"
           }) if isAdmin
+        }, {
+          key: {
+            text: "Data sharing agreement"
+          },
+          value: {
+            html: "Signed on " + (organisation.signedDSA | govukDate ) if organisation.signedDSA else "Not yet signed"
+          },
+          actions: actionLinks({
+            text: "View agreement",
+            href: thisOrganisationPath + "/data-sharing-agreement"
+          })
         }]
       }) }}
     </div>

--- a/app/views/privacy-notice.njk
+++ b/app/views/privacy-notice.njk
@@ -1,9 +1,8 @@
-{% extends "layouts/base.njk" %}
-
-{% import "macros.njk" as macro %}
+{% extends "layouts/content.njk" %}
 
 {% set title = "Privacy notice" %}
-{% set body %}Social housing lettings and sales data is collected on behalf of the Department for Levelling Up, Housing & Communities (DLUHC) for research and statistical purposes only. Data providers do not require the consent of tenants to provide the information, but tenants have the right to know how and for what purpose your data is being collected, held and used.
+
+{% set markdown %}Social housing lettings and sales data is collected on behalf of the Department for Levelling Up, Housing & Communities (DLUHC) for research and statistical purposes only. Data providers do not require the consent of tenants to provide the information, but tenants have the right to know how and for what purpose your data is being collected, held and used.
 
 The processing must have a lawful basis. In this case the processing is necessary for the performance of a task carried out in the public interest to meet a function of the Crown, a Minister of the Crown, or a government department.
 
@@ -33,13 +32,3 @@ The detail level data is anonymised and protected to minimise the risk of identi
 If you are unhappy with any aspect of this privacy notice, or how your personal information is being processed, contact the Department Data Protection Officer at: <dataprotection@communities.gsi.gov.uk>.
 
 If you are still not happy, you have the right to lodge a complaint with the Information Commissioner’s Office (ICO) at [ico.org.uk/concerns](https://ico.org.uk/concerns).{% endset %}
-
-{% block content %}
-  <h1 class="govuk-heading-xl govuk-!-width-two-thirds">{{ title }}</h1>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {{ body | govukMarkdown | safe }}
-    </div>
-  </div>
-{% endblock %}

--- a/app/views/start.njk
+++ b/app/views/start.njk
@@ -27,7 +27,6 @@
       <p>Use your account details to sign in.</p>
       <p>If you need to set up a new account, speak to your organisation’s CORE data coordinator. If you don’t know who that is, <a href="https://digital.dclg.gov.uk/jira/servicedesk/customer/portal/4/group/21">contact the helpdesk</a>.</p>
       <p>You can <a href="https://digital.dclg.gov.uk/jira/servicedesk/customer/portal/4/group/21">request an account</a> if your organisation doesn’t have one.</p>
-      <p><a href="#">Read our data sharing agreement</a>.</p>
     </div>
 
     <div class="govuk-grid-column-one-third">

--- a/scripts/generate-organisations.js
+++ b/scripts/generate-organisations.js
@@ -48,7 +48,8 @@ const generateOrganisations = () => {
           : false,
       stock: value.stock
         ? value.stock
-        : stock
+        : stock,
+      signedDSA: faker.date.recent()
     }
   })
 


### PR DESCRIPTION
Show if the data sharing agreement has been signed (ideally with the date signed), and allow users to view the agreement.