### PR TITLE
Use summary items for logs list

### DIFF
--- a/app/components/_all.scss
+++ b/app/components/_all.scss
@@ -6,6 +6,8 @@
 @import "filter-layout/filter-layout";
 @import "header/header";
 @import "input-group/input-group";
+@import "log/log";
+@import "metadata/metadata";
 @import "output/output";
 @import "pagination/pagination";
 @import "panel/panel";

--- a/app/components/log/log.scss
+++ b/app/components/log/log.scss
@@ -1,0 +1,23 @@
+.app-log {
+  border-top: 1px solid $govuk-border-colour;
+  padding-top: govuk-spacing(3);
+}
+
+.app-log__header {
+  align-items: baseline;
+  display: flex;
+}
+
+.app-log__title {
+  margin: 0 govuk-spacing(3) govuk-spacing(2) 0;
+}
+
+@include govuk-media-query(tablet) {
+  .app-log__footer {
+    text-align: right;
+  }
+
+  .app-log__footer--actor {
+    display: block;
+  }
+}

--- a/app/components/log/macro.njk
+++ b/app/components/log/macro.njk
@@ -1,0 +1,3 @@
+{% macro appLog(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/components/log/template.njk
+++ b/app/components/log/template.njk
@@ -1,0 +1,60 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+<article class="app-log">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <header class="app-log__header">
+        <h2 class="app-log__title">
+          <a class="govuk-link" href="/logs/{{ params.id }}">
+            <span class="govuk-visually-hidden">Log </span>{{ params.id }}
+          </a>
+        </h2>
+        {% if params.tenantCode or params.propertyReference %}
+        <dl class="app-metadata app-metadata--inline">
+          {% if params.tenantCode %}
+          <div class="app-metadata__item">
+            <dt class="app-metadata__term">Tenant</dt>
+            <dd class="app-metadata__definition">{{ params.tenantCode }}</dd>
+          </div>
+          {% endif %}
+          {% if params.propertyReference %}
+          <div class="app-metadata__item">
+            <dt class="app-metadata__term">Property</dt>
+            <dd class="app-metadata__definition">{{ params.propertyReference }}</dd>
+          </div>
+          {% endif %}
+        </dl>
+        {% endif %}
+      </header>
+
+      <p class="govuk-body govuk-!-margin-bottom-2">
+        {% if params.needsType %}{{ params.needsType }}<br>{% endif %}
+        Tenancy starts <time datetime="{{ params.lettingStartDate }}">{{ params.lettingStartDate | govukDate }}</time>
+      </p>
+
+      {% if params.owner or params.manager %}
+      <dl class="app-metadata">
+        {% if params.owner %}
+        <div class="app-metadata__item">
+          <dt class="app-metadata__term">Owned by</dt>
+          <dd class="app-metadata__definition">{{ params.owner }}</dd>
+        </div>
+        {% endif %}
+        {% if params.manager %}
+        <div class="app-metadata__item">
+          <dt class="app-metadata__term">Managed by</dt>
+          <dd class="app-metadata__definition">{{ params.manager }}</dd>
+        </div>
+        {% endif %}
+      </dl>
+      {% endif %}
+    </div>
+
+    <footer class="govuk-grid-column-one-third app-log__footer">
+      <p class="govuk-body govuk-!-margin-bottom-2">{{ govukTag(params.status) }}</p>
+      <p class="govuk-body">
+        Updated <time datetime="{{ params.updated }}">{{ params.updated | govukDate }}</time>
+        <span class="app-log__footer--actor">by {{ params.updatedBy }}</span>
+      </p>
+    </footer>
+  </div>
+</article>

--- a/app/components/metadata/metadata.scss
+++ b/app/components/metadata/metadata.scss
@@ -1,0 +1,23 @@
+.app-metadata {
+  @include govuk-font($size: 16, $tabular: true);
+  color: $govuk-secondary-text-colour;
+  margin-top: 0;
+
+  &--inline {
+    display: flex;
+    gap: govuk-spacing(3);
+    margin: 0;
+  }
+
+  &__item {
+    display: flex;
+  }
+
+  &__term {
+    margin-right: govuk-spacing(1);
+  }
+
+  &__definition {
+    margin-left: 0;
+  }
+}

--- a/app/data.js
+++ b/app/data.js
@@ -11,6 +11,10 @@ export default async () => ({
     '2022-23': {
       on: true,
       name: 'Use 2022/23 questions'
+    },
+    'card-logs': {
+      on: true,
+      name: 'Use log summary cards in logs views'
     }
   },
   logs,
@@ -77,13 +81,13 @@ export default async () => ({
     inProgress: {
       id: 'inProgress',
       text: 'In progress',
-      colour: 'grey',
+      colour: 'blue',
       canStart: true
     },
     completed: {
       id: 'completed',
       text: 'Completed',
-      colour: 'blue',
+      colour: 'green',
       canStart: true
     },
     active: {
@@ -94,7 +98,7 @@ export default async () => ({
     submitted: {
       id: 'completed',
       text: 'Submitted',
-      colour: 'green',
+      colour: 'purple',
       canStart: true
     },
     inactive: {

--- a/app/filters.js
+++ b/app/filters.js
@@ -134,5 +134,23 @@ export default (env) => {
     return int <= 8 ? ordinals[int - 1] : int
   }
 
+  // Convert object saved by govukDateInput to ISO-8601 formatted date
+  filters.dateObjectToIso = object => {
+    if (typeof object === 'string') {
+      return object
+    }
+
+    let day = object.day || 1
+    day = day.padStart(2, '0')
+
+    let month = object.month || 1
+    month = day.padStart(2, '0')
+
+    let year = object.year || 1970
+    year = year.padStart(4, '0')
+
+    return `${year}-${month}-${day}`
+  }
+
   return filters
 }

--- a/app/layouts/base.njk
+++ b/app/layouts/base.njk
@@ -1,5 +1,6 @@
 {% extends "template.njk" %}
 
+{% from "components/log/macro.njk" import appLog %}
 {% from "components/autocomplete/macro.njk" import appAutocomplete %}
 {% from "components/document-list/macro.njk" import appDocumentList %}
 {% from "components/filter/macro.njk" import appFilter with context %}

--- a/app/views/logs/index.njk
+++ b/app/views/logs/index.njk
@@ -69,35 +69,62 @@
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
 
-      {%- set logRows = [] -%}
-      {% for log in results | reverse %}
-        {% set row = logRows.push([{
-            html: "<a href=\"/logs/" + log.id + "\">" + log.id + "</a>"
-          }, {
-            classes: "app-!-font-tabular",
-            text: log.setup["tenant-code"] or "—"
-          }, {
-            classes: "app-!-font-tabular",
-            text: log.setup["property-reference"] or "—"
-          }, {
-            text: log.setup["letting-start-date"] | textFromInputValue | govukDate
-          }, {
-            html: log.created | govukDate
-          }, {
-            html: govukTag({
+      {% set cardResults %}
+        <h2 class="govuk-body">
+          {{ macro.tableCaption("logs", pagination.results.count, q) }}
+          <a class="govuk-link govuk-link--no-visited-state" href="#" download>Download (CSV)</a>
+        </h2>
+        {% for log in results | reverse %}
+          {{ appLog({
+            id: log.id,
+            tenantCode: log.setup["tenant-code"],
+            propertyReference: log.setup["property-reference"],
+            lettingStartDate: log.setup["letting-start-date"] | dateObjectToIso,
+            needsType: log.setup["type-of-need"] | textFromInputValue(data.questions["type-of-need"]) if log.setup["type-of-need"],
+            owner: data.organisations[log.setup["organisation-owner"]].name if isAdmin,
+            manager: data.organisations[log.setup["organisation-manager"]].name if isAdmin,
+            status: {
               classes: "govuk-tag--" + data.statuses[log.status].colour,
               text: data.statuses[log.status].text
-            }) if log.status else log.progress
-          }])
-        %}
-      {% endfor %}
-
-      {% set captionHtml %}
-        {{ macro.tableCaption("logs", pagination.results.count, q) }}
-        <a class="govuk-link govuk-link--no-visited-state" href="#" download>Download (CSV)</a>
+            } if log.status else {
+              classes: "govuk-tag--" + data.statuses.inProgress.colour,
+              text: data.statuses.inProgress.text
+            },
+            updated: log.updated | dateObjectToIso,
+            updatedBy: users[log.updatedBy].name
+          }) }}
+        {% endfor %}
       {% endset %}
 
-      {% if results.length %}
+      {% set tableResults %}
+        {% set captionHtml %}
+          {{ macro.tableCaption("logs", pagination.results.count, q) }}
+          <a class="govuk-link govuk-link--no-visited-state" href="#" download>Download (CSV)</a>
+        {% endset %}
+
+        {%- set logRows = [] -%}
+        {% for log in results | reverse %}
+          {% set row = logRows.push([{
+              html: "<a href=\"/logs/" + log.id + "\">" + log.id + "</a>"
+            }, {
+              classes: "app-!-font-tabular",
+              text: log.setup["tenant-code"] or "—"
+            }, {
+              classes: "app-!-font-tabular",
+              text: log.setup["property-reference"] or "—"
+            }, {
+              text: log.setup["letting-start-date"] | textFromInputValue | govukDate
+            }, {
+              html: log.created | govukDate
+            }, {
+              html: govukTag({
+                classes: "govuk-tag--" + data.statuses[log.status].colour,
+                text: data.statuses[log.status].text
+              }) if log.status else log.progress
+            }])
+          %}
+        {% endfor %}
+
         {% call appTableGroup({ ariaLabel: "logs" }) %}
           {{ govukTable({
             caption: captionHtml | safe,
@@ -119,6 +146,14 @@
             rows: logRows
           }) }}
         {% endcall %}
+      {% endset %}
+
+      {% if results.length %}
+        {% if data.features["card-logs"] %}
+          {{ cardResults | safe }}
+        {% else %}
+          {{ tableResults | safe }}
+        {% endif %}
 
         {{ appPagination(pagination) }}
       {% else %}


### PR DESCRIPTION
Currently we use table with multiple columns to display information about logs. This is fast breaking down as more columns are added, especially in support views. It’ll get even harder to add additional information, like type of need etc.

Instead of using a table, we can instead show bespoke summaries for logs. Information about the tenancy and property can bet shown on the left, status of the log and information about who last updated shown on the right.

### Data provider at organisation with no organisational relationships:

<img width="1160" alt="Screenshot 2022-06-07 at 16 41 08" src="https://user-images.githubusercontent.com/813383/172423420-21048cca-9862-431d-a65b-5a09d156d1f3.png">

### Support user

Shows information about who owns and manages a property:

<img width="1160" alt="Screenshot 2022-06-07 at 16 41 27" src="https://user-images.githubusercontent.com/813383/172423428-90311448-5832-4c16-849f-c23725390a22.png">