### PR TITLE
Add organisations and edit their details

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,11 +8,13 @@ import { initAll as govukFrontend } from 'govuk-frontend'
 import GOVUKPrototypeComponents from 'govuk-prototype-components'
 
 // Add app components to GOV.UK Prototype Components
+import AddAnother from '../../components/add-another/add-another.js'
 import Autocomplete from '../../components/autocomplete/autocomplete.js'
 import FilterLayout from '../../components/filter-layout/filter-layout.js'
 import Output from '../../components/output/output.js'
 
 // Add app components to GOVUKPrototypeComponents object
+GOVUKPrototypeComponents.AddAnother = AddAnother
 GOVUKPrototypeComponents.Autocomplete = Autocomplete
 GOVUKPrototypeComponents.Output = Output
 GOVUKPrototypeComponents.FilterLayout = FilterLayout

--- a/app/components/_all.scss
+++ b/app/components/_all.scss
@@ -1,3 +1,4 @@
+@import "add-another/add-another";
 @import "autocomplete/autocomplete";
 @import "button/button";
 @import "card/card";

--- a/app/components/add-another/_add-another.scss
+++ b/app/components/add-another/_add-another.scss
@@ -1,0 +1,17 @@
+.app-add-another__item {
+  margin-bottom: govuk-spacing(6);
+}
+
+.app-add-another__remove-button {
+  @include govuk-font(19);
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+
+  background-color: transparent;
+  border: none;
+  color: $govuk-link-colour;
+  cursor: pointer;
+  padding: 0;
+}
+
+

--- a/app/components/add-another/add-another.js
+++ b/app/components/add-another/add-another.js
@@ -1,0 +1,132 @@
+import { setupAutoComplete } from '../autocomplete/autocomplete.js'
+
+const getItems = (container) => {
+  return container.querySelectorAll('.app-add-another__item')
+}
+
+const createNewItem = (element) => {
+  const item = getItems(element)[0]
+  const newItem = item.cloneNode(true)
+
+  if (!hasRemoveButton(newItem)) {
+    createRemoveButton(newItem)
+  }
+
+  // Remove autocomplete wrapper as we’ll enhanced the cloned select instead
+  if (newItem.querySelector('.autocomplete__wrapper')) {
+    newItem.querySelector('.autocomplete__wrapper').remove()
+  }
+
+  const removeButton = newItem.querySelector('.app-add-another__remove-button')
+  removeButton.addEventListener('click', (event) => onRemoveButtonClick(event))
+
+  return newItem
+}
+
+const resetItem = (item) => {
+  const inputs = item.querySelectorAll('[data-name]')
+  inputs.forEach((input, index) => {
+    if (input.type === 'checkbox' || input.type === 'radio') {
+      input.checked = false
+    } else {
+      console.log('input to reset', input)
+      input.value = ''
+    }
+  })
+}
+
+const hasRemoveButton = (item) => {
+  return item.querySelectorAll('.app-add-another__remove-button').length
+}
+
+const createRemoveButton = (item) => {
+  const removeButton = document.createElement('button')
+  removeButton.type = 'button'
+  removeButton.classList.add('app-add-another__remove-button')
+  removeButton.innerText = 'Remove'
+
+  item.append(removeButton)
+}
+
+const focusHeading = () => {
+  document.querySelector('.app-add-another__heading').focus()
+}
+
+const updateAttributes = (index, item) => {
+  const inputs = item.querySelectorAll(['.govuk-input', '.govuk-select'])
+  console.log('inputs', inputs)
+
+  inputs.forEach((input) => {
+    // [data][item][0] => [data][item][1]
+    input.name = input.name.replace(/(.*\[)[\d](\])/, '$1' + index + '$2')
+
+    console.log('autoselect?', input.dataset.module)
+
+    if (input.dataset.module === 'autocomplete') {
+      // data-item-0-select => data-item-1-select
+      input.id = input.id.replace(/(.*-)[\d]*(-select)/, '$1' + index)
+
+      // Remove value
+      input.value = ''
+
+      // Set up auto complete
+      setupAutoComplete(input)
+    } else {
+      // data-item-0 => data-item-1
+      input.id = input.id.replace(/(.*-)[\d]*/, '$1' + index)
+    }
+
+    const label = item.querySelectorAll('label')[0]
+    label.setAttribute('for', input.id)
+  })
+}
+
+const onAddButtonClick = (event, container) => {
+  const item = createNewItem(container)
+
+  updateAttributes(getItems(container).length, item)
+  resetItem(item)
+
+  const firstItem = getItems(container)[0]
+  if (!hasRemoveButton(firstItem)) {
+    createRemoveButton(firstItem)
+  }
+
+  getItems(container)[getItems(container).length - 1].after(item)
+
+  item.querySelectorAll('input, textarea, select')[0].focus()
+}
+
+const onRemoveButtonClick = function (event) {
+  const item = event.target.parentNode
+  const container = item.parentNode
+  item.remove()
+
+  const items = getItems(container)
+
+  if (items.length === 1) {
+    items[0].querySelector('.app-add-another__remove-button').remove()
+  }
+
+  items.forEach((item, index) => {
+    updateAttributes(index, item)
+  })
+
+  focusHeading()
+}
+
+export default function () {
+  this.start = (element) => {
+    const addButtons = element.querySelectorAll('.app-add-another__add-button')
+    for (const addButton of addButtons) {
+      addButton.type = 'button'
+      addButton.addEventListener('click', (event) => onAddButtonClick(event, element))
+    }
+
+    const removeButtons = element.querySelectorAll('.app-add-another__remove-button')
+    for (const removeButton of removeButtons) {
+      removeButton.type = 'button'
+      removeButton.addEventListener('click', (event) => onRemoveButtonClick(event))
+    }
+  }
+};

--- a/app/components/add-another/macro.njk
+++ b/app/components/add-another/macro.njk
@@ -1,0 +1,3 @@
+{% macro appAddAnother(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/components/add-another/template.njk
+++ b/app/components/add-another/template.njk
@@ -1,0 +1,6 @@
+<div class="app-add-another__item">
+{{ caller() if caller }}
+{% if params.items.length > 1 %}
+  <button class="app-add-another__remove-button">Remove</button>
+{% endif %}
+</div>

--- a/app/components/autocomplete/autocomplete.js
+++ b/app/components/autocomplete/autocomplete.js
@@ -28,44 +28,44 @@ const enhanceOption = (option) => {
   }
 }
 
+export const setupAutoComplete = (element) => {
+  const selectOptions = Array.from(element.options)
+  const options = selectOptions.map(o => enhanceOption(o))
+  // const inError = element.querySelector('div.govuk-form-group').className.includes('error')
+  const inError = false
+  const inputValue = element.value || ''
+
+  // Autocomplete options get passed from Nunjucks params to data attributes
+  const params = element.dataset
+
+  accessibleAutocomplete.enhanceSelectElement({
+    defaultValue: inError ? '' : inputValue,
+    selectElement: element,
+    autoselect: params.autoselect === 'true',
+    displayMenu: params.displayMenu,
+    minLength: params.minLength ? parseInt(params.minLength) : 0,
+    showAllValues: params.showAllValues === 'true',
+    name: element.name,
+    showNoOptionsFound: params.showNoOptionsFound === 'true',
+    source: (query, populateResults) => {
+      if (/\S/.test(query)) {
+        populateResults(sort(query, options))
+      }
+    },
+    templates: { suggestion: (value) => suggestion(value, options) },
+    onConfirm: (val) => {
+      const selectedOption = [].filter.call(selectOptions, option => (option.textContent || option.innerText) === val)[0]
+      if (selectedOption) selectedOption.selected = true
+    }
+  })
+
+  if (inError) {
+    element.querySelector('input').value = inputValue
+  }
+}
+
 export default function () {
   this.start = (element) => {
-    // Autocomplete options get passed from Nunjucks params to data attributes
-    const params = element.dataset
-
-    const setupAutoComplete = (element) => {
-      const selectOptions = Array.from(element.options)
-      const options = selectOptions.map(o => enhanceOption(o))
-      // const inError = element.querySelector('div.govuk-form-group').className.includes('error')
-      const inError = false
-      const inputValue = element.value || ''
-
-      accessibleAutocomplete.enhanceSelectElement({
-        defaultValue: inError ? '' : inputValue,
-        selectElement: element,
-        autoselect: params.autoselect === 'true',
-        displayMenu: params.displayMenu,
-        minLength: params.minLength ? parseInt(params.minLength) : 0,
-        showAllValues: params.showAllValues === 'true',
-        name: element.name,
-        showNoOptionsFound: params.showNoOptionsFound === 'true',
-        source: (query, populateResults) => {
-          if (/\S/.test(query)) {
-            populateResults(sort(query, options))
-          }
-        },
-        templates: { suggestion: (value) => suggestion(value, options) },
-        onConfirm: (val) => {
-          const selectedOption = [].filter.call(selectOptions, option => (option.textContent || option.innerText) === val)[0]
-          if (selectedOption) selectedOption.selected = true
-        }
-      })
-
-      if (inError) {
-        element.querySelector('input').value = inputValue
-      }
-    }
-
     setupAutoComplete(element)
   }
 }

--- a/app/data/organisation-settings.js
+++ b/app/data/organisation-settings.js
@@ -3,6 +3,10 @@ import appData from '../data.js'
 const data = await appData()
 
 export function organisationSettings (organisation) {
+  if (!organisation['rent-periods']) {
+    return false
+  }
+
   const rentPeriods = data.rentPeriods.filter(period =>
     organisation['rent-periods'].includes(period.value))
 

--- a/app/data/questions/type-of-organisation.js
+++ b/app/data/questions/type-of-organisation.js
@@ -1,0 +1,7 @@
+export default [{
+  text: 'Local authority',
+  value: 'Local authority'
+}, {
+  text: 'Housing association',
+  value: 'Housing association'
+}]

--- a/app/datasets/registered-providers.js
+++ b/app/datasets/registered-providers.js
@@ -1,80 +1,71 @@
 export default {
   DLUHC: {
     name: 'Department for Levelling Up, Housing & Communities',
-    address: '2 Marsham Street, London. SW1P 4DF',
+    address: {
+      line1: '2 Marsham Street',
+      line2: 'London',
+      postalCode: 'SW1P 4DF'
+    },
     tel: '0303 444 1209',
     type: 'Not applicable',
-    areas: [],
-    stock: false
+    isAgent: 'false',
+    isOwner: 'false'
   },
   PARENT1: { // Example parent organisation
     name: 'Own Homes Limited',
     'registration-date': '2021-10-04',
     designation: 'Non-profit',
     'corporate-form': 'Company',
-    address: 'Fairview House, 18 Water Street, Fareham, Hampshire. PO16 7BB',
+    address: {
+      line1: 'Fairview House, 18 Water Street',
+      line2: 'Fareham',
+      postalCode: 'PO16 7BB'
+    },
     tel: '01329 234600',
-    areas: [
-      'E06000036',
-      'E06000037',
-      'E06000038',
-      'E06000039',
-      'E06000040',
-      'E06000041',
-      'E06000043',
-      'E06000044',
-      'E06000045',
-      'E06000046',
-      'E07000223',
-      'E07000224',
-      'E07000225',
-      'E07000226',
-      'E07000227',
-      'E07000228',
-      'E07000229'
-    ],
-    parents: [],
-    children: [
+    isAgent: 'false',
+    owners: [],
+    isOwner: 'true',
+    agents: [
       'CHILD1',
       'CHILD2'
-    ],
-    stock: true
+    ]
   },
   CHILD1: { // Example child organisation
     name: 'Housing Management Limited',
     'registration-date': '2021-10-04',
     designation: 'Non-profit',
     'corporate-form': 'Company',
-    address: '34 High Street, Exemplar. EX2 2AG',
+    address: {
+      line1: '34 High Street',
+      line2: 'Exemplar',
+      postalCode: 'EX2 2AG'
+    },
     tel: '01432 098765',
-    areas: [
-      'E07000220',
-      'E07000218',
-      'E07000221'
-    ],
-    parents: [
+    isAgent: 'true',
+    owners: [
       'PARENT1'
     ],
-    children: [
+    isOwner: 'true',
+    agents: [
       'CHILD2'
-    ],
-    stock: true
+    ]
   },
   CHILD2: { // Example child organisation that is also a parent
     name: 'Homes Charity CIC',
     'registration-date': '2021-10-04',
     designation: 'Non-profit',
     'corporate-form': 'Charitable company',
-    address: '123a Sandsford Road, Exemplar. EX32 5HC',
+    address: {
+      line1: '123a Sandsford Road',
+      line2: 'Exemplar',
+      postalCode: 'EX32 5HC'
+    },
     tel: '01432 980111',
-    areas: [
-      'E07000218',
-      'E07000221'
-    ],
-    parents: [
+    isAgent: 'true',
+    owners: [
       'PARENT1'
     ],
-    stock: false
+    isOwner: 'false'
   },
   4568: {
     name: 'Bolton at Home Limited',

--- a/app/filters.js
+++ b/app/filters.js
@@ -61,6 +61,10 @@ export default (env) => {
     text = text || 'name'
     value = value || 'id'
 
+    if (!array) {
+      return
+    }
+
     if (!Array.isArray(array)) {
       array = utils.objectToArray(array)
     }

--- a/app/layouts/base.njk
+++ b/app/layouts/base.njk
@@ -1,9 +1,10 @@
 {% extends "template.njk" %}
 
-{% from "components/log/macro.njk" import appLog %}
+{% from "components/add-another/macro.njk" import appAddAnother %}
 {% from "components/autocomplete/macro.njk" import appAutocomplete %}
 {% from "components/document-list/macro.njk" import appDocumentList %}
 {% from "components/filter/macro.njk" import appFilter with context %}
+{% from "components/log/macro.njk" import appLog %}
 {% from "components/output/macro.njk" import appOutput %}
 {% from "components/pagination/macro.njk" import appPagination with context %}
 {% from "components/primary-navigation/macro.njk" import appPrimaryNavigation %}

--- a/app/routes/logs.js
+++ b/app/routes/logs.js
@@ -41,7 +41,7 @@ export const logRoutes = (router) => {
     logs.filter(log => log.type === type)
 
     // Filter: organisation’s logs (if scoped to organisation)
-    if (organisationId) {
+    if (organisationId && logs) {
       logs = logs.filter(log => {
         return log.setup['organisation-manager'] === organisationId ||
           log.setup['organisation-owner'] === organisationId
@@ -236,7 +236,7 @@ export const logRoutes = (router) => {
       // Organisation data
       const organisationId = account?.organisationId || 'PARENT1'
       const organisation = utils.getEntityById(organisations, organisationId)
-      const childOrganisations = organisation.children || []
+      const childOrganisations = organisation.agents || []
       const userOrganisations = organisationId.concat(childOrganisations)
 
       const managingOrganisations = Object.values(organisations)

--- a/app/routes/schemes.js
+++ b/app/routes/schemes.js
@@ -2,9 +2,8 @@ import { wizard } from 'govuk-prototype-rig'
 import * as utils from '../utils.js'
 import localAuthorities from '../datasets/local-authorities.js'
 
-const getSchemePaths = (req) => {
-  const { schemeId } = req.params
-  const schemePath = `/schemes/${schemeId}/`
+const getSchemeWizardPaths = (req) => {
+  const schemePath = `/schemes/${req.params.schemeId}/`
 
   const journey = {
     [`${schemePath}details`]: {},
@@ -45,7 +44,7 @@ export const schemeRoutes = (router) => {
     if (organisationId) {
       const organisationRelationships = [
         organisationId,
-        ...(organisation.children ? organisation.children : [])
+        ...(organisation.agents ? organisation.agents : [])
       ]
 
       // Only return users with a relationship with organisation
@@ -82,7 +81,7 @@ export const schemeRoutes = (router) => {
    * Scheme
    */
   router.all('/schemes/:schemeId/:view?/:itemId?', (req, res, next) => {
-    res.locals.paths = getSchemePaths(req)
+    res.locals.paths = getSchemeWizardPaths(req)
     next()
   })
 
@@ -152,7 +151,6 @@ export const schemeRoutes = (router) => {
     const { account, schemes } = req.session.data
     const schemeId = utils.generateUniqueId()
 
-    // Create a new blank scheme in session data
     // Assign to user’s organisation (only DC at owning organisation can create)
     schemes[schemeId] = {
       created: new Date().toISOString(),
@@ -184,8 +182,8 @@ export const schemeRoutes = (router) => {
     // Data coordinators can add schemes to own organisation and its children
     const managedOrganisations = [organisation].concat(
       allOrganisations.filter(organisation => {
-        if (organisation.parents) {
-          return organisation.parents.includes(organisationId)
+        if (organisation.owners) {
+          return organisation.owners.includes(organisationId)
         }
 
         return false

--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -27,7 +27,7 @@ export const userRoutes = (router) => {
       const organisation = organisations[organisationId]
       const organisationRelationships = [
         organisationId,
-        ...(organisation.children ? organisation.children : [])
+        ...(organisation.agents ? organisation.agents : [])
       ]
 
       // Only return users with a relationship with organisation
@@ -92,8 +92,8 @@ export const userRoutes = (router) => {
     // Data coordinators can add users to own organisation and its children
     const managedOrganisations = [organisation].concat(
       allOrganisations.filter(organisation => {
-        if (organisation.parents) {
-          return organisation.parents.includes(organisationId)
+        if (organisation.owners) {
+          return organisation.owners.includes(organisationId)
         }
 
         return false

--- a/app/views/macros.njk
+++ b/app/views/macros.njk
@@ -67,17 +67,17 @@
   <h2 class="govuk-visually-hidden">{{ title }}</h2>
 {% endmacro %}
 
-{% macro organisationRelationshipHtml(organisations, organisation, type) %}
-  {% if organisation[type] | length > 1 %}
+{% macro organisationHtml(organisations, organisation) %}
+  {% if organisation | length > 1 %}
     <ul class="govuk-list govuk-list--bullet">
-    {% for parentId in organisation[type] %}
-      <li>{{ organisations[parentId].name }}</li>
+    {% for organisationId in organisation %}
+      <li>{{ organisations[organisationId[1]].name or organisations[organisationId].name }}</li>
     {% endfor %}
     </ul>
-  {% elif organisation[type] | length == 1 %}
-    {{ organisations[organisation[type][0]].name }}
+  {% elif organisation | length == 1 %}
+    <p class="govuk-body">{{ organisations[organisation[1]].name or organisations[organisation].name }}</p>
   {% else %}
-    None
+    <p class="govuk-body">None</p>
   {% endif %}
 {% endmacro %}
 

--- a/app/views/organisations/_answers-details.njk
+++ b/app/views/organisations/_answers-details.njk
@@ -1,0 +1,69 @@
+{{ govukSummaryList({
+  rows: [{
+    key: {
+      text: "Name"
+    },
+    value: {
+      text: organisation.name
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/details",
+      visuallyHiddenText: "name"
+    }) if isAdmin or isCoordinator
+  }, {
+    key: {
+      text: "Address"
+    },
+    value: {
+      html: [organisation.address.line1, organisation.address.line2, organisation.address.postalCode].join("\n") | nl2br
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/details",
+      visuallyHiddenText: "address"
+    }) if isAdmin or isCoordinator
+  }, {
+    key: {
+      text: "Phone number"
+    },
+    value: {
+      text: organisation.tel
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/details",
+      visuallyHiddenText: "telephone number"
+    }) if isAdmin or isCoordinator
+  }, {
+    key: {
+      text: "Type of provider"
+    },
+    value: {
+      text: organisation.type
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/details",
+      visuallyHiddenText: "type"
+    }) if isAdmin
+  }, {
+    key: {
+      text: "Registration number"
+    },
+    value: {
+      text: organisation.registration
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/details",
+      visuallyHiddenText: "type"
+    }) if isAdmin
+  }, {
+    key: {
+      text: "Data sharing"
+    },
+    value: {
+      html: "Data sharing agreement accepted" if organisation.acceptedDSA else "Data sharing agreement not yet accepted"
+    },
+    actions: actionLinks({
+      text: "View agreement",
+      href: thisOrganisationPath + "/data-sharing-agreement"
+    })
+  }]
+}) }}

--- a/app/views/organisations/_answers-relationships.njk
+++ b/app/views/organisations/_answers-relationships.njk
@@ -1,0 +1,88 @@
+{% set isAgent = organisation.isAgent == "true" %}
+{% set isOwner = organisation.isOwner == "true" %}
+{% set isOwnerAgent = organisation.isOwnerAgent == "true" %}
+
+{% set outgoingPeriodsHtml %}
+  {% if organisationSettings.rentPeriods %}
+    {% if organisationSettings.rentPeriods.length > 1 %}
+      <ul class="govuk-list govuk-list--bullet">
+      {% for period in organisationSettings.rentPeriods %}
+        <li>{{ period.text }}</li>
+      {% endfor %}
+      </ul>
+    {% else %}
+      {% set period = organisationSettings.rentPeriods | first %}
+      {{ period.text }}
+    {% endif %}
+  {% endif %}
+{% endset %}
+
+{{ govukSummaryList({
+  rows: [{
+    key: {
+      text: "Owns housing stock"
+    },
+    value: {
+      text: organisation.isOwner | textFromInputValue(data.questions["yes-no"])
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/is-owner",
+      visuallyHiddenText: "if owns housing stock"
+    }) if isAdmin or isCoordinator
+  }, {
+    key: {
+      text: "Manages own stock"
+    },
+    value: {
+      html: organisation.isOwnerAgent | textFromInputValue(data.questions["yes-no"])
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/is-owner-agent",
+      visuallyHiddenText: "if manages own stock"
+    }) if isAdmin or isCoordinator
+  } if isOwnerAgent, {
+    key: {
+      text: "Stock managed by"
+    },
+    value: {
+      html: macro.organisationHtml(organisations, organisation.agents)
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/agents",
+      visuallyHiddenText: "managing agents"
+    }) if isAdmin or isCoordinator
+  } if isOwner and not isOwnerAgent, {
+    key: {
+      text: "Manages propeties"
+    },
+    value: {
+      html: organisation.isAgent | textFromInputValue(data.questions["yes-no"])
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/is-agent",
+      visuallyHiddenText: "if manages propeties"
+    }) if isAdmin or isCoordinator
+  }, {
+    key: {
+      text: "Manages properties for"
+    },
+    value: {
+      html: macro.organisationHtml(organisations, organisation.owners)
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/owners",
+      visuallyHiddenText: "manages properties for"
+    }) if isAdmin or isCoordinator
+  } if isAgent, {
+    key: {
+      text: "Rent periods"
+    },
+    value: {
+      html: outgoingPeriodsHtml
+    },
+    actions: actionLinks({
+      href: thisOrganisationPath + "/rent-periods",
+      visuallyHiddenText: "rent periods"
+    }) if isAdmin or isCoordinator
+  } if isAgent or isOwnerAgent]
+}) }}

--- a/app/views/organisations/agents.njk
+++ b/app/views/organisations/agents.njk
@@ -1,0 +1,51 @@
+{% extends "layouts/question.njk" %}
+
+{% import "macros.njk" as macro %}
+
+{% set title = "Which providers manage properties for this organisation?" %}
+{% set caption = organisation.name %}
+{% set required = true %}
+
+{% if organisation.agents %}
+  {# Editing an existing organisation #}
+  {% set buttonText = "Continue" %}
+  {% set formAction = organisationPath + "/check-updated-answers" %}
+{% endif %}
+
+{% macro addAnotherAgent(index, items) %}
+  {% call appAddAnother({
+    items: items
+  }) %}
+    {{ appAutocomplete(decorate({
+      formGroup: {
+        classes: "govuk-!-margin-bottom-1"
+      },
+      label: {
+        text: "Name of managing agent"
+      },
+      allowEmpty: true,
+      showNoOptionsFound: true,
+      items: organisations | optionItems
+    }, ["organisations", organisation.id, "agents", index])) }}
+  {% endcall %}
+{% endmacro %}
+
+{% block question %}
+  <h1 class="govuk-heading-l app-add-another__heading" tabindex="-1">
+    <span class="govuk-caption-l">{{ caption }}</span>
+    {{ title | noOrphans | safe }}
+  </h1>
+
+  <div data-module="add-another">
+    {% for agent in organisation.agents %}
+      {{ addAnotherAgent(loop.index0, organisation.agents) }}
+    {% else %}
+      {{ addAnotherAgent(0, organisation.agents) }}
+    {% endfor %}
+
+    {{ govukButton({
+      classes: "govuk-button--secondary app-add-another__add-button",
+      text: "Add another managing agent"
+    }) }}
+  </div>
+{% endblock %}

--- a/app/views/organisations/check-your-answers.njk
+++ b/app/views/organisations/check-your-answers.njk
@@ -1,0 +1,21 @@
+{% extends "layouts/form.njk" %}
+
+{% set title = "Check your answers before creating this organisation" %}
+
+{% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters-from-desktop">
+      {{ macro.heading(title) }}
+
+      <h3 class="govuk-heading-m">Details</h3>
+      {% include "organisations/_answers-details.njk" %}
+
+      <h3 class="govuk-heading-m govuk-!-margin-top-8">Housing stock ownership and management</h3>
+      {% include "organisations/_answers-relationships.njk" %}
+
+      {{ govukButton(decorate({
+        text: "Create organisation"
+      })) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/organisations/data-sharing-agreement.njk
+++ b/app/views/organisations/data-sharing-agreement.njk
@@ -12,11 +12,9 @@
 {% set markdown %}
 ## {{ organisation.name }} and Department for Levelling Up, Housing and Communities
 
-This agreement is made the {{ signedDSADay | ordinal }} day of {{ signedDSAMonth }} {{ signedDSAYear }}.
-
 **between**
 
-1. {{ organisation.name }} of {{ organisation.address }} (“CORE Data Provider”)
+1. {{ organisation.name }} of {{ organisation.address.line1 }}, {{ organisation.address.line2 }} (“CORE Data Provider”)
 
 and
 

--- a/app/views/organisations/details.njk
+++ b/app/views/organisations/details.njk
@@ -1,0 +1,106 @@
+{% extends "layouts/question.njk" %}
+
+{% set required = true %}
+
+{% if organisation.name %}
+  {# Editing an existing organisation #}
+  {% set caption = organisation.name %}
+  {% set title = "Organisation details" %}
+  {% set buttonText = "Save changes" %}
+  {% set formAction = organisationPath + "/update" %}
+{% else %}
+  {% set title = "Create a new organisation" %}
+{% endif %}
+
+{% block question %}
+  {{ macro.heading(title, caption) }}
+
+  {{ govukInput({
+    decorate: ["organisations", organisation.id, "name"],
+    formGroup: {
+      classes: "govuk-!-margin-bottom-4"
+    },
+    label: {
+      classes: "govuk-label--m",
+      text: "Name"
+    },
+    spellcheck: false
+  }) }}
+
+  {% call govukFieldset({
+    legend: {
+      text: "Address",
+      classes: "govuk-fieldset__legend--m"
+    }
+  }) %}
+
+    {{ govukInput({
+      decorate: ["organisations", organisation.id, "address", "line1"],
+      label: {
+        text: "Address line 1"
+      },
+      autocomplete: "address-line1"
+    }) }}
+
+    {{ govukInput({
+      decorate: ["organisations", organisation.id, "address", "line2"],
+      label: {
+        text: "Address line 2 (optional)"
+      },
+      autocomplete: "address-line2"
+    }) }}
+
+    {{ govukInput({
+      decorate: ["organisations", organisation.id, "address", "postalCode"],
+      label: {
+        text: "Postcode"
+      },
+      classes: "govuk-input--width-10",
+      autocomplete: "postal-code"
+    }) }}
+  {% endcall %}
+
+  {{ govukInput({
+    classes: "govuk-input--width-20",
+    decorate: ["organisations", organisation.id, "tel"],
+    label: {
+      classes: "govuk-label--m",
+      text: "Phone number"
+    },
+    type: "tel"
+  }) }}
+
+  {{ govukRadios({
+    decorate: ["organisations", organisation.id, "type"],
+    fieldset: {
+      legend: {
+        classes: "govuk-fieldset__legend--m",
+        text: "Type of social housing provider"
+      }
+    },
+    items: data.questions["type-of-organisation"]
+  }) }}
+
+  {{ govukInput({
+    decorate: ["organisations", organisation.id, "registration"],
+    label: {
+      classes: "govuk-label--m",
+      text: "Regulator of Social Housing registration number"
+    },
+    classes: "govuk-input--width-10"
+  }) }}
+
+  {{ govukCheckboxes({
+    fieldset: {
+      legend: {
+        text: "Data sharing agreement",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    decorate: ["organisations", organisation.id, "acceptedDSA"],
+    items: [{
+      value: "true",
+      text: "The organisation’s data protection officer has read and accepted DLUHC’s data sharing agreement."
+    }]
+  }) if organisation.draft }}
+{% endblock %}

--- a/app/views/organisations/index.njk
+++ b/app/views/organisations/index.njk
@@ -13,7 +13,7 @@
 
   <div class="govuk-button-group">
     {{ govukButton({
-      href: "#",
+      href: "/organisations/new",
       text: "Create a new organisation"
     }) }}
     <a class="govuk-link" href="#">Merge organisations</a>

--- a/app/views/organisations/is-agent.njk
+++ b/app/views/organisations/is-agent.njk
@@ -1,0 +1,24 @@
+{% extends "layouts/question.njk" %}
+
+{% set title = "Does this organisation manage properties for other housing providers?" %}
+{% set caption = organisation.name %}
+{% set required = true %}
+
+{% if organisation.isAgent %}
+  {# Editing an existing organisation #}
+  {% set buttonText = "Continue" %}
+  {% set formAction = organisationPath + "/check-updated-answers" %}
+{% endif %}
+
+{% block question %}
+  {{ govukRadios({
+    decorate: ["organisations", organisation.id, "isAgent"],
+    fieldset: {
+      legend: {
+        classes: "govuk-fieldset__legend--l",
+        html: macro.fieldsetHeading(title, caption)
+      }
+    },
+    items: data.questions["yes-no"]
+  }) }}
+{% endblock %}

--- a/app/views/organisations/is-owner-agent.njk
+++ b/app/views/organisations/is-owner-agent.njk
@@ -1,0 +1,24 @@
+{% extends "layouts/question.njk" %}
+
+{% set title = "Does this organisation manage its own housing stock?" %}
+{% set caption = organisation.name %}
+{% set required = true %}
+
+{% if organisation.isOwnerAgent %}
+  {# Editing an existing organisation #}
+  {% set buttonText = "Continue" %}
+  {% set formAction = organisationPath + "/check-updated-answers" %}
+{% endif %}
+
+{% block question %}
+  {{ govukRadios({
+    decorate: ["organisations", organisation.id, "isOwnerAgent"],
+    fieldset: {
+      legend: {
+        classes: "govuk-fieldset__legend--l",
+        html: macro.fieldsetHeading(title, caption)
+      }
+    },
+    items: data.questions["yes-no"]
+  }) }}
+{% endblock %}

--- a/app/views/organisations/is-owner.njk
+++ b/app/views/organisations/is-owner.njk
@@ -1,0 +1,24 @@
+{% extends "layouts/question.njk" %}
+
+{% set title = "Does this organisation own housing stock?" %}
+{% set caption = organisation.name %}
+{% set required = true %}
+
+{% if organisation.isOwner %}
+  {# Editing an existing organisation #}
+  {% set buttonText = "Continue" %}
+  {% set formAction = organisationPath + "/check-updated-answers" %}
+{% endif %}
+
+{% block question %}
+  {{ govukRadios({
+    decorate: ["organisations", organisation.id, "isOwner"],
+    fieldset: {
+      legend: {
+        classes: "govuk-fieldset__legend--l",
+        html: macro.fieldsetHeading(title, caption)
+      }
+    },
+    items: data.questions["yes-no"]
+  }) }}
+{% endblock %}

--- a/app/views/organisations/organisation.njk
+++ b/app/views/organisations/organisation.njk
@@ -7,6 +7,11 @@
 {% set caption = thisOrganisation.name %}
 
 {% block content %}
+  {{ govukNotificationBanner({
+    text: organisation.name + " has been " + query.success + ".",
+    type: "success"
+  }) if query.success }}
+
   {{ adminNavigation(title) if isAdmin else macro.heading(title, caption) }}
 
   <div class="govuk-grid-row">
@@ -24,121 +29,11 @@
         </p>
       {% endif %}
 
-{% set outgoingPeriodsHtml %}
-  {% if organisationSettings.rentPeriods.length > 1 %}
-    <ul class="govuk-list govuk-list--bullet">
-    {% for period in organisationSettings.rentPeriods %}
-      <li>{{ period.text }}</li>
-    {% endfor %}
-    </ul>
-  {% else %}
-    {% set period = organisationSettings.rentPeriods | first %}
-    {{ period.text }}
-  {% endif %}
-{% endset %}
+      <h3 class="govuk-heading-m">Details</h3>
+      {% include "organisations/_answers-details.njk" %}
 
-      {{ govukSummaryList({
-        rows: [{
-          key: {
-            text: "Name"
-          },
-          value: {
-            text: organisation.name
-          },
-          actions: actionLinks({
-            href: "#",
-            visuallyHiddenText: "name"
-          }) if isAdmin or isCoordinator
-        }, {
-          key: {
-            text: "Address"
-          },
-          value: {
-            html: organisation.address | replace(", ", "\n") | replace(". ", "\n") | nl2br
-          },
-          actions: actionLinks({
-            href: "#",
-            visuallyHiddenText: "address"
-          }) if isAdmin or isCoordinator
-        }, {
-          key: {
-            text: "Telephone number"
-          },
-          value: {
-            text: organisation.tel
-          },
-          actions: actionLinks({
-            href: "#",
-            visuallyHiddenText: "telephone number"
-          }) if isAdmin or isCoordinator
-        }, {
-          key: {
-            text: "Type"
-          },
-          value: {
-            text: organisation.type
-          },
-          actions: actionLinks({
-            href: "#",
-            visuallyHiddenText: "type"
-          }) if isAdmin
-        }, {
-          key: {
-            text: "Rent periods"
-          },
-          value: {
-            html: outgoingPeriodsHtml
-          },
-          actions: actionLinks({
-            href: thisOrganisationPath + "/rent-periods",
-            visuallyHiddenText: "rent periods"
-          }) if isAdmin or isCoordinator
-        }, {
-          key: {
-            text: "Holds own stock"
-          },
-          value: {
-            text: "Yes" if organisation.stock else "No"
-          },
-          actions: actionLinks({
-            href: "#",
-            visuallyHiddenText: "if holds housing stock"
-          }) if isAdmin
-        }, {
-          key: {
-            text: "Other stock owners"
-          },
-          value: {
-            html: macro.organisationRelationshipHtml(organisations, organisation, "parents")
-          },
-          actions: actionLinks({
-            href: "#",
-            visuallyHiddenText: "parent organisations"
-          }) if isAdmin
-        }, {
-          key: {
-            text: "Managing agents"
-          },
-          value: {
-            html: macro.organisationRelationshipHtml(organisations, organisation, "children")
-          },
-          actions: actionLinks({
-            href: "#",
-            visuallyHiddenText: "child organisations"
-          }) if isAdmin
-        }, {
-          key: {
-            text: "Data sharing agreement"
-          },
-          value: {
-            html: "Signed on " + (organisation.signedDSA | govukDate ) if organisation.signedDSA else "Not yet signed"
-          },
-          actions: actionLinks({
-            text: "View agreement",
-            href: thisOrganisationPath + "/data-sharing-agreement"
-          })
-        }]
-      }) }}
+      <h3 class="govuk-heading-m govuk-!-margin-top-8">Housing stock ownership and management</h3>
+      {% include "organisations/_answers-relationships.njk" %}
     </div>
 
     <div class="govuk-grid-column-one-third-from-desktop">

--- a/app/views/organisations/owners.njk
+++ b/app/views/organisations/owners.njk
@@ -1,0 +1,51 @@
+{% extends "layouts/question.njk" %}
+
+{% import "macros.njk" as macro %}
+
+{% set title = "Which housing providers does this organisation manage properties for?" %}
+{% set caption = organisation.name %}
+{% set required = true %}
+
+{% if organisation.owners %}
+  {# Editing an existing organisation #}
+  {% set buttonText = "Continue" %}
+  {% set formAction = organisationPath + "/check-updated-answers" %}
+{% endif %}
+
+{% macro addAnotherOwner(index, items) %}
+  {% call appAddAnother({
+    items: items
+  }) %}
+    {{ appAutocomplete(decorate({
+      formGroup: {
+        classes: "govuk-!-margin-bottom-1"
+      },
+      label: {
+        text: "Name of housing provider"
+      },
+      allowEmpty: true,
+      showNoOptionsFound: true,
+      items: organisations | optionItems
+    }, ["organisations", organisation.id, "owners", index])) }}
+  {% endcall %}
+{% endmacro %}
+
+{% block question %}
+  <h1 class="govuk-heading-l app-add-another__heading" tabindex="-1">
+    <span class="govuk-caption-l">{{ caption }}</span>
+    {{ title | noOrphans | safe }}
+  </h1>
+
+  <div data-module="add-another">
+    {% for agent in organisation.owners %}
+      {{ addAnotherOwner(loop.index0, organisation.owners) }}
+    {% else %}
+      {{ addAnotherOwner(0, organisation.owners) }}
+    {% endfor %}
+
+    {{ govukButton({
+      classes: "govuk-button--secondary app-add-another__add-button",
+      text: "Add another housing provider"
+    }) }}
+  </div>
+{% endblock %}

--- a/app/views/organisations/reactivate.njk
+++ b/app/views/organisations/reactivate.njk
@@ -9,7 +9,7 @@
       {{ macro.heading(title, organisation.name) }}
 
       {{ govukButton({
-        text: "I’m sure – reactivate this organisation"
+        text: "I’m sure – reactivate this organisation"
       }) }}
 
       <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ thisOrganisationPath }}">No - I’ve changed my mind</a></p>

--- a/app/views/organisations/rent-periods.njk
+++ b/app/views/organisations/rent-periods.njk
@@ -5,6 +5,12 @@
 {% set buttonText = "Save changes" %}
 {% set required = true %}
 
+{% if organisation["rent-periods"] %}
+  {# Editing an existing organisation #}
+  {% set buttonText = "Continue" %}
+  {% set formAction = organisationPath + "/check-updated-answers" %}
+{% endif %}
+
 {% block question %}
   {{ govukCheckboxes({
     decorate: ["organisations", thisOrganisation.id, "rent-periods"],

--- a/app/views/organisations/update.njk
+++ b/app/views/organisations/update.njk
@@ -1,0 +1,52 @@
+{% extends "layouts/form.njk" %}
+
+{% set title = "Check your ownership and management changes before updating this organisation" %}
+
+{% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters-from-desktop">
+      {{ macro.heading(title, caption) }}
+
+      {% include "organisations/_answers-relationships.njk" %}
+
+      {{ govukRadios({
+        decorate: ["schemes", scheme.id, "updated"],
+        fieldset: {
+          legend: {
+            classes: "govuk-fieldset__legend--m",
+            html: "When do these changes apply?"
+          }
+        },
+        items: [{
+          text: "From the start of the current collection period",
+          value: "period"
+        }, {
+          text: "From a certain date",
+          value: "false",
+          conditional: {
+            html: govukDateInput({
+              decorate: ["schemes", scheme.id, "updated-from"],
+              fieldset: {
+                legend: {
+                  classes: "govuk-fieldset__legend--s",
+                  text: "Date changes apply from"
+                }
+              },
+              hint: {
+                text: "For example, 12 11 2020."
+              },
+              items: data.questions["date-full"]
+            })
+          }
+        }]
+      }) }}
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Update organisation"
+        }) }}
+        <a class="govuk-link" href="{{ organisationPath }}">Cancel</a>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/scripts/generate-organisations.js
+++ b/scripts/generate-organisations.js
@@ -8,24 +8,42 @@ const generateOrganisations = () => {
   const organisations = {}
 
   Object.entries(registeredProviders).forEach(([key, value]) => {
-    const stock = value.designation === 'Local authority' || value['corporate-form'] === 'Company'
+    const isAgent = (value.designation !== 'Local authority').toString()
+    const isOwner = (value.designation === 'Local authority' || value['corporate-form'] === 'Company').toString()
+
+    // If organisation owns stock, give it some agents (aka children)
+    const agents = (isOwner === 'true')
+      ? faker.helpers.arrayElements(
+        Object.keys(registeredProviders),
+        3
+      )
+      : false
+
+    // If organisation manages stock, give it some owners (aka parents)
+    const owners = isAgent
+      ? faker.helpers.arrayElements(
+        Object.keys(registeredProviders),
+        2
+      )
+      : false
 
     organisations[key] = {
       id: key,
       name: value.name,
       address: value.address
         ? value.address
-        : [
-            faker.address.streetAddress(),
-            faker.address.cityName(),
-            faker.address.zipCode()
-          ].join(', '),
+        : {
+            line1: faker.address.streetAddress(),
+            line2: faker.address.cityName(),
+            postalCode: faker.address.zipCode()
+          },
       tel: value.tel
         ? value.tel
         : faker.phone.phoneNumber(),
       type: value.designation === 'Local authority'
         ? 'Local authority'
         : 'Housing association',
+      registration: key,
       'rent-periods': faker.helpers.arrayElements([
         'fortnightly',
         'every-4-weeks',
@@ -38,26 +56,11 @@ const generateOrganisations = () => {
         'weekly-52',
         'weekly-53'
       ]),
-      parents: value.parents
-        ? value.parents
-        : (value.designation !== 'Local authority')
-            ? faker.helpers.arrayElements(
-              Object.keys(registeredProviders),
-              2
-            )
-            : false,
-      children: value.children
-        ? value.children
-        : stock
-          ? faker.helpers.arrayElements(
-            Object.keys(registeredProviders),
-            3
-          )
-          : false,
-      stock: value.stock
-        ? value.stock
-        : stock,
-      signedDSA: faker.date.past(3)
+      isAgent: value.isAgent || isAgent,
+      owners: value.owners || owners,
+      isOwner: value.isOwner || isOwner,
+      agents: value.agents || agents,
+      acceptedDSA: 'true'
     }
   })
 


### PR DESCRIPTION
Update organisation pages so that:

* Support users can **create a new organisation**. As part of the flow, they are asked if a data protection officer at the organisation has accepted the DSA. This value can’t be edited once the organisation has been created.
* Support users and data coordinators can **change the basic details of an organisation**. These values can be updated without needing any confirmation.
* Support users and data coordinators can **change answers relating to an organisation’s relationship with other organisations**. Users are asked for the date any of these changes take effect from. Might need to add some additional guidance about how this change affects the appliances of logs by users in the affected organisations.

  Support users and data coordinators *can’t* add parents to an organisation, only children – parent organisations contract out to children, after all. May need to add a screen that tells users to contact the parent organisation or contact the Helpdesk if they need a parent adding.

  Rent period questions and answers are only shown if an organisation manages properties.

### Todo

- [x] Review content. Still unsure about the terms we should use: agents v managers, stock v properties etc.
- [x] Add interaction for adding multiple managing agents.