### PR TITLE
Use ‘scheme’ instead of ‘service’

### DIFF
--- a/app/layouts/base.njk
+++ b/app/layouts/base.njk
@@ -73,7 +73,7 @@
       active: path.startsWith("/logs")
     }, {
       href: "/schemes",
-      text: "Supported housing",
+      text: "Schemes",
       active: path.startsWith("/schemes")
     }] if isAdmin else [{
       href: userOrganisationPath + "/logs",
@@ -82,7 +82,7 @@
         path.startsWith("/logs")
     }, {
       href: userOrganisationPath + "/schemes",
-      text: "Supported housing",
+      text: "Schemes",
       active: path.startsWith(userOrganisationPath + "/schemes") or
         path.startsWith("/schemes")
     } if (isOwningOrg == true and isCoordinator), {

--- a/app/views/logs/setup/_answers.njk
+++ b/app/views/logs/setup/_answers.njk
@@ -67,14 +67,14 @@
     }) if not logSubmitted
   } if isLet, {
     key: {
-      text: "Service name"
+      text: "Scheme name"
     },
     value: {
       html: schemeHtml
     },
     actions: actionLinks({
       href: sectionPath + "/scheme",
-      visuallyHiddenText: "service name"
+      visuallyHiddenText: "scheme name"
     }) if not logSubmitted
   } if isSupported, {
     key: {

--- a/app/views/logs/setup/scheme-results.njk
+++ b/app/views/logs/setup/scheme-results.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/question.njk" %}
 
-{% set title = "Select a supported housing service" %}
+{% set title = "Select a supported housing scheme" %}
 {% set buttonText = "Continue" %}
 {% set questionId = "schemeId" %}
 
@@ -13,7 +13,7 @@
       }
     },
     hint: {
-      text: "Services found matching ‘"+ data.schemes[log[section.id].schemeId].name + "’"
+      text: "Schemes found matching ‘"+ data.schemes[log[section.id].schemeId].name + "’"
     },
     items: data.questions.scheme
   }) }}
@@ -27,7 +27,7 @@
       text: "Try another search"
     },
     hint: {
-      text: "Enter service name or postcode"
+      text: "Enter scheme name or postcode"
     }
   }) }}
 {% endblock %}

--- a/app/views/logs/setup/scheme.njk
+++ b/app/views/logs/setup/scheme.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/question.njk" %}
 
-{% set title = "What service is this log for?" %}
+{% set title = "What scheme is this log for?" %}
 {% set questionId = "schemeId" %}
 
 {% block question %}
@@ -9,7 +9,7 @@
       html: macro.heading(title, caption)
     },
     hint: {
-      text: "Enter service name or postcode"
+      text: "Enter scheme name or postcode"
     },
     allowEmpty: true,
     showNoOptionsFound: true,
@@ -17,8 +17,8 @@
   }, ["logs", log.id, section.id, questionId])) }}
 
   {% if isOwningOrg == true or isAdmin %}
-    <p class="govuk-body govuk-!-margin-bottom-6">or <a class="govuk-link" href="/schemes/new">create a new supported housing service</a>.</p>
+    <p class="govuk-body govuk-!-margin-bottom-6">or <a class="govuk-link" href="/schemes/new">create a new supported housing scheme</a>.</p>
   {% else %}
-    <p class="govuk-body govuk-!-margin-bottom-6">If you can’t find the supported housing service you’re looking for or not sure which to choose, contact a data coordinator at {{ data.organisations[log[section.id]["organisation-owner"]].name | textFromInputValue }}.</p>
+    <p class="govuk-body govuk-!-margin-bottom-6">If you can’t find the supported housing scheme you’re looking for or not sure which to choose, contact a data coordinator at {{ data.organisations[log[section.id]["organisation-owner"]].name | textFromInputValue }}.</p>
   {% endif %}
 {% endblock %}

--- a/app/views/macros.njk
+++ b/app/views/macros.njk
@@ -55,7 +55,7 @@
       active: path.startsWith(thisOrganisationPath + "/logs")
     }, {
       href: thisOrganisationPath + "/schemes",
-      text: "Supported housing",
+      text: "Schemes",
       active: path.startsWith(thisOrganisationPath + "/schemes")
     }, {
       href: thisOrganisationPath + "/users",

--- a/app/views/schemes/_answers.njk
+++ b/app/views/schemes/_answers.njk
@@ -75,7 +75,7 @@
 {{ govukTabs({
   items: [
     {
-      label: "Service",
+      label: "Scheme",
       id: "details",
       panel: {
         html: detailsHtml

--- a/app/views/schemes/_filters.njk
+++ b/app/views/schemes/_filters.njk
@@ -10,7 +10,7 @@
     }
   },
   items: [{
-    text: "Show deactivated services",
+    text: "Show deactivated schemes",
     value: "active",
     checked: "true"
   }]

--- a/app/views/schemes/_scheme-answers.njk
+++ b/app/views/schemes/_scheme-answers.njk
@@ -1,7 +1,7 @@
 {{ govukSummaryList({
   rows: [{
     key: {
-      text: "Service code"
+      text: "Scheme code"
     },
     value: {
       classes: "app-!-font-tabular",
@@ -42,14 +42,14 @@
     }) if not scheme.deactivated
   }, {
     key: {
-      text: "Type of service"
+      text: "Type of scheme"
     },
     value: {
       text: scheme.type | textFromInputValue(data.questions["type-of-scheme"])
     },
     actions: actionLinks({
       href: schemePath + "/details",
-      visuallyHiddenText: "type of service"
+      visuallyHiddenText: "type of scheme"
     }) if not scheme.deactivated
   }, {
     key: {
@@ -60,7 +60,7 @@
     },
     actions: actionLinks({
       href: schemePath + "/details",
-      visuallyHiddenText: "if service is a registered as a care home"
+      visuallyHiddenText: "if scheme is a registered as a care home"
     }) if not scheme.deactivated
   }, {
     key: {

--- a/app/views/schemes/_scheme-layout.njk
+++ b/app/views/schemes/_scheme-layout.njk
@@ -41,23 +41,23 @@
 
   <p class="govuk-button-group">
     {% if scheme.deactivated %}
-      <span class="app-!-colour-muted govuk-!-margin-right-2">This service has been deactivated.</span>
+      <span class="app-!-colour-muted govuk-!-margin-right-2">This scheme has been deactivated.</span>
       {% if isCoordinator or isAdmin %}
-        <a class="govuk-link" href="{{ schemePath }}/reactivate">Reactivate service</a>
+        <a class="govuk-link" href="{{ schemePath }}/reactivate">Reactivate scheme</a>
       {% endif %}
     {% else %}
       {% if isCoordinator or isAdmin %}
-        <a class="govuk-link" href="{{ schemePath }}/deactivate">Deactivate service</a>
+        <a class="govuk-link" href="{{ schemePath }}/deactivate">Deactivate scheme</a>
       {% endif %}
       {% if isAdmin %}
-        <a class="govuk-link" href="{{ schemePath }}/delete">Delete service</a>
+        <a class="govuk-link" href="{{ schemePath }}/delete">Delete scheme</a>
       {% endif %}
     {% endif %}
   </p>
 
   {{ appSubNavigation({
     items: [{
-      text: "Service",
+      text: "Scheme",
       href: schemePath,
       active: section == "scheme"
     }, {

--- a/app/views/schemes/check-your-answers.njk
+++ b/app/views/schemes/check-your-answers.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/form.njk" %}
 
-{% set title = "Check your answers before creating this service" %}
+{% set title = "Check your answers before creating this scheme" %}
 
 {% block form %}
   <div class="govuk-grid-row">
@@ -10,7 +10,7 @@
       {% include "schemes/_answers.njk" %}
 
       {{ govukButton(decorate({
-        text: "Create service",
+        text: "Create scheme",
         value: "active"
       }, ["schemes", scheme.id, "status"])) }}
     </div>

--- a/app/views/schemes/deactivate.njk
+++ b/app/views/schemes/deactivate.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/form.njk" %}
 
-{% set title = "Are you sure you want to deactivate this service?" %}
+{% set title = "Are you sure you want to deactivate this scheme?" %}
 {% set backLink = schemePath %}
 
 {% block form %}
@@ -8,13 +8,13 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title, scheme.name) }}
 
-      <p>Deactivating this service will prevent data providers in the organisations you work with from submitting logs for this service.</p>
+      <p>Deactivating this scheme will prevent data providers in the organisations you work with from submitting logs for this scheme.</p>
 
       <p>Existing logs will not be affected.</p>
 
       {{ govukButton({
         classes: "govuk-button--warning",
-        text: "I’m sure – deactivate this service"
+        text: "I’m sure – deactivate this scheme"
       }) }}
 
       <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ schemePath }}">No - I’ve changed my mind</a></p>

--- a/app/views/schemes/delete.njk
+++ b/app/views/schemes/delete.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/form.njk" %}
 
-{% set title = "Are you sure you want to delete this service?" %}
+{% set title = "Are you sure you want to delete this scheme?" %}
 {% set backLink = schemePath %}
 
 {% block form %}
@@ -8,18 +8,18 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title, scheme.name) }}
 
-      <p>Deleting this service will remove it from {{ organisation.name }}’s list of supported housing services.</p>
+      <p>Deleting this scheme will remove it from {{ organisation.name }}’s list of supported housing schemes.</p>
 
-      <p>Data providers in the organisations that work with {{ organisation.name }} will no longer be able to select this service.</p>
+      <p>Data providers in the organisations that work with {{ organisation.name }} will no longer be able to select this scheme.</p>
 
-      <p>123 logs that have selected this service will lose answers to questions and be marked as incomplete.</p>
+      <p>123 logs that have selected this scheme will lose answers to questions and be marked as incomplete.</p>
 
       <p>Logs submitted in previous collection windows will not be affected.</p>
 
 
       {{ govukButton({
         classes: "govuk-button--warning",
-        text: "I’m sure – delete this service"
+        text: "I’m sure – delete this scheme"
       }) }}
 
       <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ schemePath }}">No - I’ve changed my mind</a></p>

--- a/app/views/schemes/details.njk
+++ b/app/views/schemes/details.njk
@@ -5,12 +5,12 @@
 {% if scheme.name %}
   {# Editing an existing scheme #}
   {% set caption = scheme.name %}
-  {% set title = "Service details" %}
+  {% set title = "Scheme details" %}
   {% set buttonText = "Continue" %}
   {% set formAction = schemePath + "/check-updated-answers" %}
   {% set hasAnsweredQuestion = true %}
 {% else %}
-  {% set title = "Create a new supported housing service" %}
+  {% set title = "Create a new supported housing scheme" %}
 {% endif %}
 
 {% block question %}
@@ -29,10 +29,10 @@
     },
     label: {
       classes: "govuk-label--m",
-      text: "Service name"
+      text: "Scheme name"
     },
     hint: {
-      text: "This is how you’ll refer to this supported housing service within your organisation. For example, the name could relate to the address or location. You’ll be able to see the client group when selecting it."
+      text: "This is how you’ll refer to this supported housing scheme within your organisation. For example, the name could relate to the address or location. You’ll be able to see the client group when selecting it."
     },
     spellcheck: false
   }) }}
@@ -41,7 +41,7 @@
     decorate: ["schemes", scheme.id, "confidential"],
     items: [{
       value: "true",
-      text: "This service contains confidential information"
+      text: "This scheme contains confidential information"
     }]
   }) }}
 
@@ -51,7 +51,7 @@
     fieldset: {
       legend: {
         classes: "govuk-label--m",
-        text: "Which organisation manages this service?"
+        text: "Which organisation manages this scheme?"
       }
     },
     allowEmpty: true,
@@ -62,7 +62,7 @@
   {{ appAutocomplete(decorate({
     label: {
       classes: "govuk-label--m",
-      html: "Which organisation manages this service?"
+      html: "Which organisation manages this scheme?"
     },
     hint: {
       text: "Enter organisation name"
@@ -77,7 +77,7 @@
     fieldset: {
       legend: {
         classes: "govuk-fieldset__legend--m",
-        text: "What is this type of service?"
+        text: "What is this type of scheme?"
       }
     },
     items: data.questions["type-of-scheme"]
@@ -88,7 +88,7 @@
     fieldset: {
       legend: {
         classes: "govuk-fieldset__legend--m",
-        text: "Is this service registered under the Care Standards Act 2000?"
+        text: "Is this scheme registered under the Care Standards Act 2000?"
       }
     },
     items: data.questions["registered-home"]

--- a/app/views/schemes/index.njk
+++ b/app/views/schemes/index.njk
@@ -3,7 +3,7 @@
 {% import "macros.njk" as macro %}
 {% from "macros.njk" import adminNavigation with context %}
 
-{% set title = "Supported housing services" %}
+{% set title = "Supported housing schemes" %}
 {% set caption = thisOrganisation.name %}
 {% set isGlobalView = isAdmin and path.startsWith("/schemes") %}
 
@@ -23,14 +23,14 @@
     <div class="govuk-button-group app-filter-toggle">
       {{ govukButton({
         href: "/schemes/new",
-        text: "Create a new supported housing service"
+        text: "Create a new supported housing scheme"
       }) }}
     </div>
 
     {{ govukDetails({
       classes: "govuk-!-width-two-thirds",
-      summaryText: "What is a supported housing service?",
-      text: "A supported service or scheme provides shared or self-contained housing for a particular client group, for example younger or vulnerable people. A single service can contain multiple units, for example bedrooms in shared houses or a bungalow with 3 bedrooms."
+      summaryText: "What is a supported housing scheme?",
+      text: "A supported housing scheme (also known as a ‘supported housing service’) provides shared or self-contained housing for a particular client group, for example younger or vulnerable people. A single scheme can contain multiple units, for example bedrooms in shared houses or a bungalow with 3 bedrooms."
     }) }}
 
     <div class="app-filter-layout__filter">
@@ -46,7 +46,7 @@
         classes: "govuk-!-margin-bottom-4",
         label: {
           classes: "govuk-!-margin-bottom-2",
-          text: "Search by service name, code or postcode"
+          text: "Search by scheme name, code or postcode"
         }
       }) }}
 
@@ -80,14 +80,14 @@
       {% endfor %}
 
       {% if results.length %}
-        {% call appTableGroup({ ariaLabel: "services" }) %}
+        {% call appTableGroup({ ariaLabel: "schemes" }) %}
           {{ govukTable({
-            caption: macro.tableCaption("services", pagination.results.count, q) | safe,
+            caption: macro.tableCaption("schemes", pagination.results.count, q) | safe,
             captionClasses: "govuk-table__caption--m govuk-!-font-size-19 govuk-!-font-weight-regular",
             head: [{
               html: "Code"
             }, {
-              text: "Service"
+              text: "Scheme"
             }, {
               text: "Managing agent"
             }, {
@@ -99,7 +99,7 @@
 
         {{ appPagination(pagination) }}
       {% else %}
-        <p class="govuk-body"><strong>No supported housing services found</strong></p>
+        <p class="govuk-body"><strong>No supported housing schemes found</strong></p>
       {% endif %}
     </div>
   </div>

--- a/app/views/schemes/location.njk
+++ b/app/views/schemes/location.njk
@@ -10,7 +10,7 @@
   {% set formAction = schemePath + "/location/" + itemId + "/update" %}
   {% set hasAnsweredQuestion = true %}
 {% else %}
-  {% set title = "Add a location to this service" %}
+  {% set title = "Add a location to this scheme" %}
   {% set formAction = schemePath %}
 {% endif %}
 

--- a/app/views/schemes/primary-client-group.njk
+++ b/app/views/schemes/primary-client-group.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/question.njk" %}
 
-{% set title = "What client group is this service intended for?" %}
+{% set title = "What client group is this scheme intended for?" %}
 {% set caption = scheme.name %}
 {% set required = true %}
 

--- a/app/views/schemes/reactivate.njk
+++ b/app/views/schemes/reactivate.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/form.njk" %}
 
-{% set title = "Are you sure you want to reactivate this service?" %}
+{% set title = "Are you sure you want to reactivate this scheme?" %}
 {% set backLink = schemePath %}
 
 {% block form %}
@@ -8,10 +8,10 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title, scheme.name) }}
 
-      <p>Reactivating this service will enable data providers in all organisations you work with to submit logs for this service.</p>
+      <p>Reactivating this scheme will enable data providers in all organisations you work with to submit logs for this scheme.</p>
 
       {{ govukButton({
-        text: "I’m sure – reactivate this service"
+        text: "I’m sure – reactivate this scheme"
       }) }}
 
       <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ schemePath }}">No - I’ve changed my mind</a></p>

--- a/app/views/schemes/secondary-client-group.njk
+++ b/app/views/schemes/secondary-client-group.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/question.njk" %}
 
-{% set title = "Does this service provide for another client group?" %}
+{% set title = "Does this scheme provide for another client group?" %}
 {% set caption = scheme.name %}
 {% set required = true %}
 

--- a/app/views/schemes/support.njk
+++ b/app/views/schemes/support.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/question.njk" %}
 
-{% set title = "What support does this service provide?" %}
+{% set title = "What support does this scheme provide?" %}
 {% set caption = scheme.name %}
 {% set required = true %}
 

--- a/app/views/schemes/update.njk
+++ b/app/views/schemes/update.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/form.njk" %}
 
-{% set title = "Check your changes before updating this service" %}
+{% set title = "Check your changes before updating this scheme" %}
 
 {% block form %}
   <div class="govuk-grid-row">
@@ -43,7 +43,7 @@
 
       <div class="govuk-button-group">
         {{ govukButton({
-          text: "Update service"
+          text: "Update scheme"
         }) }}
         <a class="govuk-link" href="{{ userOrganisationPath }}/schemes/">Cancel</a>
       </div>

--- a/app/views/start.njk
+++ b/app/views/start.njk
@@ -16,7 +16,7 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>upload data for multiple lettings and sales</li>
           <li>transfer data using an API</li>
-          <li>create supported housing services</li>
+          <li>create supported housing schemes</li>
           <li>set up and manage user accounts</li>
         </ul>
       -->

--- a/app/views/users/deactivate.njk
+++ b/app/views/users/deactivate.njk
@@ -8,12 +8,12 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title, user.name) }}
 
-      <p>Deactivating this user will mean they can no longer access this service to submit CORE data.</p>
+      <p>Deactivating this user will mean they can no longer access this scheme to submit CORE data.</p>
       <p>Any logs this user has already submitted will not be affected.</p>
 
       {{ govukButton({
         classes: "govuk-button--warning",
-        text: "I’m sure – deactivate this user"
+        text: "I’m sure – deactivate this user"
       }) }}
 
       <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ userPath }}">No - I’ve changed my mind</a></p>


### PR DESCRIPTION
We chose ‘services’ based on some early UR insights, where some users commented on ‘schemes’ being an outdated term. However, using ‘services’ instead has shown some drawbacks:

* ‘Service’ is a word we already use to describe… well, our service! So we now have ‘services within the service’
* ‘Service’ is such a broad term, we often have to say ‘Supported housing service’ to distinguish it
* That has led us to using ‘Supported housing’ in navigation items (Rachel raised some concerns about this being potentially confusing for anyone looking to add a supported housing log)
* ‘Schemes’ is the term used in the existing service. Maintaining the same term will help smooth the transition, if only a little
* We ourselves keeping using the word scheme, which is probably a good indicator that the word ‘service’ is not working

## Changes

* Replace ‘service’ with ‘scheme’
* Use ‘Schemes’ (or ‘Scheme’) in navigation items