### PR TITLE
Scheme improvements

### DIFF
--- a/app/data/questions/scheme.js
+++ b/app/data/questions/scheme.js
@@ -24,7 +24,7 @@ Object.entries(schemes).forEach(([key, value]) => {
   const schemeLocationCount = Object.entries(value.locations).length
   const hintText = schemeLocationCount > 1
     ? `${schemeLocationCount} locations`
-    : `${value.locations.l1.address}`
+    : `${value.locations.l1.name}`
 
   // Add postcodes to search synonyms
   const synonyms = []

--- a/app/datasets/seed-schemes.js
+++ b/app/datasets/seed-schemes.js
@@ -1,406 +1,406 @@
 export default [{
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '4 Blackwood House',
   group: 'South East'
 }, {
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '15-17 Defender Road',
   group: 'South West'
 }, {
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'West View House',
   group: 'South East'
 }, {
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '13 Hampage Green',
   group: 'South East'
 }, {
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '3-5 Cortis Avenue',
   group: 'South East'
 }, {
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '7 Weller House',
   group: 'South East'
 }, {
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '9 Buriton House',
   group: 'South East'
 }, {
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Oxford Road',
   group: 'South West'
 }, {
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Victoria Road South',
   group: 'South East'
 }, {
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Waterloo Road',
   group: 'South East'
 }, {
   created: '2020-11-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '76 Fitzroy Street',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '6 Hertford Place',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '236 Northern Parade',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '8 Foxcote House',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '4 Coniston House',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '6 Somerset Road',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '30 Cranbury Avenue',
   group: 'South West'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'McCarthy House',
   group: 'South West'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Sussex Street',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '24 Northern Parade',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '8 Eskdale House',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '20A Dursley Crescent',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '9 Outram Road',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Tempe Market Avenue',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '204 Northern Parade',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '7 Outram Road',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '4 Melbourne House',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '12a Finchdean Road',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '4 Shaftesbury Road',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'All Saints',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '5 Regents Court',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '44 Halstead Road',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '8 Southwick House',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Portsmouth Foyer',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '2 Tankerton Close',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Devonia Villas',
   group: 'South West'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Miriam House',
   group: 'South West'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Flats A-D 7 Outram Road',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '39 Montgomerie Road',
   group: 'South East'
 }, {
   created: '2020-11-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: "143 St James' Road",
   group: 'South East'
 }, {
   created: '2020-11-17',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '12 Brisbane House',
   group: 'South East'
 }, {
   created: '2020-11-25',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '12 Ringwood House',
   group: 'South East'
 }, {
   created: '2020-11-25',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '8 Artillery Close',
   group: 'South East'
 }, {
   created: '2020-11-27',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Leslie Nation Court',
   group: 'South East'
 }, {
   created: '2021-01-20',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '4 Carberry Court',
   group: 'South East'
 }, {
   created: '2021-02-26',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '4 Target Road',
   group: 'South East'
 }, {
   created: '2021-03-10',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '132 Edgbaston House',
   group: 'South East'
 }, {
   created: '2021-04-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '539 Northern Parade',
   group: 'South East'
 }, {
   created: '2021-04-13',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '11 Aldershot House',
   group: 'South East'
 }, {
   created: '2021-04-14',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '80 Linkenholt Way',
   group: 'South East'
 }, {
   created: '2021-04-15',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '60 Wakefords Way',
   group: 'South East'
 }, {
   created: '2021-05-10',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '52 Pickwick House',
   group: 'South East'
 }, {
   created: '2021-05-10',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '8 Chipstead House',
   group: 'South East'
 }, {
   created: '2021-05-27',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Oakdene House',
   group: 'South East'
 }, {
   created: '2021-07-09',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '8 Shackleton House',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Gibbs Terrace',
   group: 'North'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '12 Queens Road',
   group: 'North'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '107 London Road',
   group: 'North'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '210 Newtown Road',
   group: 'North'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Dene Court, Dene Road',
   group: 'North'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Newbury Flats',
   group: 'North'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Prospect Court',
   group: 'North'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '32 Cranbury Avenue',
   group: 'South West'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '1 Foster Road',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Oakdene Flats',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Nile House',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '250 Southampton Road',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '101 Gosport Road',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'St Albans Rd',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Kings Road',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Due of Edinburgh, Cumberland Street',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Yew House',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '27-29 Herbert Road',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Acton Lodge',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Hope House',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '400 Locksway Road',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '207 Goldsmith Avenue',
   group: 'South East'
 }, {
   created: '2021-07-23',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: 'Mill House',
   group: 'Salvation Army'
 }, {
   created: '2021-08-10',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '363 Hawthorn Crescent',
   group: 'South East'
 }, {
   created: '2021-08-10',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '6 Canberra House',
   group: 'South East'
 }, {
   created: '2021-08-10',
-  organisationId: 'OWNER',
+  ownerId: 'OWNER',
   name: '35 Cornwall Road',
   group: 'South East'
 }]

--- a/app/routes/schemes.js
+++ b/app/routes/schemes.js
@@ -98,6 +98,7 @@ export const schemeRoutes = (router) => {
     // Get locations as array sorted by scheme name
     let locations = scheme.locations
     locations = utils.objectToArray(locations)
+    locations = utils.sortArray(locations, 'postcode')
 
     // Pagination
     const page = parseInt(req.query.page) || 1
@@ -132,7 +133,7 @@ export const schemeRoutes = (router) => {
   })
 
   /**
-   * Create location
+   * Create scheme location
    */
   router.get('/schemes/:schemeId/location/new', (req, res) => {
     const { schemes } = req.session.data
@@ -151,7 +152,7 @@ export const schemeRoutes = (router) => {
   })
 
   /**
-   * Confirm delete location
+   * Confirm delete scheme location
    */
   router.get('/schemes/:schemeId/location/:itemId/delete', (req, res) => {
     const { schemes } = req.session.data
@@ -168,7 +169,7 @@ export const schemeRoutes = (router) => {
   })
 
   /**
-   * Update location
+   * Update scheme location
    */
   router.post('/schemes/:schemeId/location/:itemId/:view', (req, res) => {
     const { schemes } = req.session.data
@@ -178,7 +179,7 @@ export const schemeRoutes = (router) => {
     const locationsPath = `/schemes/${schemeId}/locations`
 
     if (view === 'update') {
-      req.flash('success', `${location.address} has been updated.`)
+      req.flash('success', `${location.postcode} has been updated.`)
       res.redirect(locationsPath)
     }
 

--- a/app/routes/schemes.js
+++ b/app/routes/schemes.js
@@ -86,6 +86,44 @@ export const schemeRoutes = (router) => {
   })
 
   /**
+   * List scheme locations
+   */
+  router.all('/schemes/:schemeId/locations', (req, res) => {
+    const { schemes } = req.session.data
+    const { schemeId } = req.params
+
+    const scheme = schemes[schemeId]
+    const schemePath = `/schemes/${schemeId}`
+
+    // Get locations as array sorted by scheme name
+    let locations = scheme.locations
+    locations = utils.objectToArray(locations)
+
+    // Pagination
+    const page = parseInt(req.query.page) || 1
+    const limit = parseInt(req.query.limit) || 50
+    const skip = (page - 1) * limit
+    const results = locations.slice(skip, skip + limit)
+    const pagination = utils.getPaginationItems(
+      page,
+      limit,
+      locations.length
+    )
+
+    // Search query
+    const q = req.query.q || req.body.q
+
+    res.render('schemes/locations', {
+      query: req.query,
+      q,
+      scheme,
+      schemePath,
+      results,
+      pagination
+    })
+  })
+
+  /**
    * Scheme
    */
   router.all('/schemes/:schemeId/:view?/:itemId?', (req, res, next) => {

--- a/app/views/logs/setup/_answers.njk
+++ b/app/views/logs/setup/_answers.njk
@@ -23,7 +23,7 @@
     {% set itemId = log[section.id].schemeLocationId %}
     {{ data.schemes[schemedId].locations[itemId].postcode }}<br>
     <span class="app-!-colour-muted">
-      {{ data.schemes[schemedId].locations[itemId]["local-authority"] }}
+      {{ data.schemes[schemedId].locations[itemId].name }}
     </span>
   {% else %}
     <span class="app-!-colour-muted">You didn’t answer this question</span>

--- a/app/views/logs/setup/scheme-location.njk
+++ b/app/views/logs/setup/scheme-location.njk
@@ -15,7 +15,7 @@
     items: data.schemes[schemeId].locations | optionItems({
       text: "postcode",
       value: "id",
-      hint: "local-authority"
+      hint: "name"
     })
   }) }}
 {% endblock %}

--- a/app/views/schemes/_answers.njk
+++ b/app/views/schemes/_answers.njk
@@ -6,7 +6,7 @@
 
 {% set locationsHtml %}
   {% for itemId, location in scheme.locations %}
-    <h2 class="govuk-heading-m">{{ location.address }}</h2>
+    <h2 class="govuk-heading-m">{{ location.postcode }}</h2>
     {{ govukSummaryList({
       classes: "govuk-!-margin-bottom-9" if not loop.last else "",
       rows: [{

--- a/app/views/schemes/_scheme-answers.njk
+++ b/app/views/schemes/_scheme-answers.njk
@@ -31,6 +31,17 @@
     }) if not scheme.deactivated
   }, {
     key: {
+      text: "Housing stock owned by"
+    },
+    value: {
+      text: organisations[scheme.ownerId].name
+    },
+    actions: actionLinks({
+      href: schemePath + "/details",
+      visuallyHiddenText: "who owns the housing stock for this scheme"
+    }) if not scheme.deactivated
+  } if isAdmin, {
+    key: {
       text: "Managed by"
     },
     value: {

--- a/app/views/schemes/_scheme-layout.njk
+++ b/app/views/schemes/_scheme-layout.njk
@@ -35,15 +35,11 @@
       href: schemePath,
       active: section == "scheme"
     }, {
-      text: locationsCount + " locations" if locationsCount > 1 else "Location",
+      text: "Locations",
       href: schemePath + "/locations",
       active: section == "locations"
     }]
   }) }}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-      {% block sectionContent %}{% endblock %}
-    </div>
-  </div>
+  {% block sectionContent %}{% endblock %}
 {% endblock %}

--- a/app/views/schemes/delete-location.njk
+++ b/app/views/schemes/delete-location.njk
@@ -6,7 +6,7 @@
 {% block form %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      {{ macro.heading(title, location.address) }}
+      {{ macro.heading(title, location.postcode) }}
 
       <p>Deleting this location will remove it from the list of available locations for {{ scheme.name }}.</p>
 

--- a/app/views/schemes/details.njk
+++ b/app/views/schemes/details.njk
@@ -17,12 +17,6 @@
   {{ macro.heading(title, caption) }}
 
   {{ govukInput({
-    decorate: ["schemes", scheme.id, "organisationId"],
-    value: organisationId,
-    type: "hidden"
-  }) }}
-
-  {{ govukInput({
     decorate: ["schemes", scheme.id, "name"],
     formGroup: {
       classes: "govuk-!-margin-bottom-4"
@@ -45,27 +39,30 @@
     }]
   }) }}
 
-  {# Ideally show radio options if number of organisations is less than 10 #}
-  {# govukRadios({
-    decorate: ["schemes", scheme.id, "agentId"],
-    fieldset: {
-      legend: {
+  {% if isAdmin %}
+    {# Ideally show radio options if number of organisations is less than 10 #}
+    {{ appAutocomplete(decorate({
+      label: {
         classes: "govuk-label--m",
-        text: "Which organisation manages this scheme?"
-      }
-    },
-    allowEmpty: true,
-    showNoOptionsFound: true,
-    items: managedOrganisations | optionItems
-  }) #}
+        html: "Which organisation owns the housing stock for this scheme?"
+      },
+      allowEmpty: true,
+      showNoOptionsFound: true,
+      items: owners | optionItems
+    }, ["schemes", scheme.id, "ownerId"])) }}
+  {% else %}
+    {{ govukInput({
+      decorate: ["schemes", scheme.id, "ownerId"],
+      value: scheme.ownerId,
+      type: "hidden"
+    }) }}
+  {% endif %}
 
+  {# Ideally show radio options if number of organisations is less than 10 #}
   {{ appAutocomplete(decorate({
     label: {
       classes: "govuk-label--m",
       html: "Which organisation manages this scheme?"
-    },
-    hint: {
-      text: "Enter organisation name"
     },
     allowEmpty: true,
     showNoOptionsFound: true,

--- a/app/views/schemes/index.njk
+++ b/app/views/schemes/index.njk
@@ -41,15 +41,6 @@
     </div>
 
     <div class="app-filter-layout__content">
-      {{ appSearch({
-        classes: "govuk-!-margin-bottom-4",
-        label: {
-          text: "Search by scheme name, code or postcode"
-        }
-      }) }}
-
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
-
       {% set schemeRows = [] %}
       {% for scheme in results %}
         {% set schemePath = "/schemes/" + scheme.id %}
@@ -78,6 +69,15 @@
       {% endfor %}
 
       {% if results.length %}
+        {{ appSearch({
+          classes: "govuk-!-margin-bottom-4",
+          label: {
+            text: "Search by scheme name, code or postcode"
+          }
+        }) }}
+
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+
         {% call appTableGroup({ ariaLabel: "schemes" }) %}
           {{ govukTable({
             caption: macro.tableCaption("schemes", pagination.results.count, q) | safe,

--- a/app/views/schemes/index.njk
+++ b/app/views/schemes/index.njk
@@ -44,14 +44,6 @@
       {% set schemeRows = [] %}
       {% for scheme in results %}
         {% set schemePath = "/schemes/" + scheme.id %}
-        {% set schemeLocationCount = scheme.locations | length %}
-        {% set schemeDescription %}
-          {% if schemeLocationCount > 1 %}
-            {{ schemeLocationCount }} locations
-          {% else %}
-            {{ scheme.locations.l1.address }}, {{ scheme.locations.l1.postcode }}
-          {% endif %}
-        {% endset %}
         {% set schemePath = schemePath + "/check-your-answers" if scheme.status == "inProgress" else schemePath %}
         {% set row = schemeRows.push([{
             classes: "govuk-!-text-align-left",

--- a/app/views/schemes/location.njk
+++ b/app/views/schemes/location.njk
@@ -5,7 +5,7 @@
 
 {% if scheme.locations[itemId] %}
   {# Editing an existing location #}
-  {% set title = "Location details for " + scheme.locations[itemId].address %}
+  {% set title = "Location details for " + scheme.locations[itemId].postcode %}
   {% set buttonText = "Continue" %}
   {% set formAction = schemePath + "/location/" + itemId + "/update" %}
   {% set hasAnsweredQuestion = true %}
@@ -32,6 +32,17 @@
       text: "For example, SW1P 4DF."
     }
   }) if scheme.draft or isAdmin }}
+
+  {{ govukInput({
+    decorate: ["schemes", scheme.id, "locations", itemId, "name"],
+    label: {
+      classes: "govuk-label--m",
+      text: "Name (optional)"
+    },
+    hint: {
+      text: "This is how you’ll refer to this location within your organisation"
+    }
+  }) }}
 
   {{ govukRadios({
     decorate: ["schemes", scheme.id, "locations", itemId, "type-of-unit"],

--- a/app/views/schemes/locations.njk
+++ b/app/views/schemes/locations.njk
@@ -17,7 +17,7 @@
       text: "S" + scheme.id + "-" + location.postcode | replace(" ", ""),
       format: "numeric"
     }, {
-      html: macro.entityHtml(location.postcode, locationPath, location["local-authority"]) if location.postcode else "Not known"
+      html: macro.entityHtml(location.postcode, locationPath, location.name) if location.postcode else "Not known"
     }, {
       text: location["type-of-unit"] | textFromInputValue(data.questions["type-of-unit"].supported)
     }, {

--- a/app/views/schemes/locations.njk
+++ b/app/views/schemes/locations.njk
@@ -9,59 +9,54 @@
     href: schemePath + "/location/new"
   }) if not scheme.deactivated }}
 
-  {% for itemId, location in scheme.locations %}
-    {#-
-      Data coordinators can edit locations
-      Admins can edit and delete locations
-    -#}
-    {{ xGovukSummaryCard({
-      titleText: location.address or location.postcode,
-      actions: actionLinks(
-        [{
-          href: schemePath + "/location/" + itemId,
-          text: "Edit",
-          visuallyHiddenText: location.address or location.postcode
-        }, {
-          href: schemePath + "/location/" + itemId + "/delete",
-          text: "Delete",
-          visuallyHiddenText: location.address or location.postcode
-        }] if isAdmin else [{
-          href: schemePath + "/location/" + itemId,
-          text: "Edit",
-          visuallyHiddenText: location.address or location.postcode
-        }]
-      ) if not scheme.deactivated,
-      classes: "govuk-!-margin-bottom-6",
-      rows: [{
-        key: {
-          text: "Location code"
-        },
-        value: {
-          classes: "app-!-font-tabular",
-          text: "S" + scheme.id + "-" + location.postcode | replace(" ", "")
-        }
-      }, {
-        key: {
-          text: "Postcode"
-        },
-        value: {
-          text: macro.postcodeHtml(location.postcode, location["local-authority"]) if location.postcode else "Not known"
-        }
-      }, {
-        key: {
-          text: "Type of unit"
-        },
-        value: {
-          text: location["type-of-unit"] | textFromInputValue(data.questions["type-of-unit"].supported)
-        }
-      }, {
-        key: {
-          text: "Wheelchair adaptation"
-        },
-        value: {
-          text: location["is-adapted"] | textFromInputValue(data.questions["yes-no"])
-        }
-      }]
-    }) }}
+  {% set locationRows = [] %}
+  {% for location in results %}
+    {% set locationPath = "/schemes/" + scheme.id + "/location/" + itemId %}
+    {% set row = locationRows.push([{
+      classes: "govuk-!-text-align-left",
+      text: "S" + scheme.id + "-" + location.postcode | replace(" ", ""),
+      format: "numeric"
+    }, {
+      html: macro.entityHtml(location.postcode, locationPath, location["local-authority"]) if location.postcode else "Not known"
+    }, {
+      text: location["type-of-unit"] | textFromInputValue(data.questions["type-of-unit"].supported)
+    }, {
+      text: location["is-adapted"] | textFromInputValue(data.questions["yes-no"])
+    }, {
+      html: "<a href=\"" + locationPath + "/delete\">Delete<span class=\"govuk-visually-hidden\">" + location.postcode + "</span>" if isAdmin and not scheme.deactivated
+    }])
+    %}
   {% endfor %}
+
+  {% if locationsCount > 0 %}
+    {{ appSearch({
+      classes: "govuk-!-margin-bottom-4",
+      label: {
+        text: "Search by location code or postcode"
+      }
+    }) }}
+
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+
+    {% call appTableGroup({ ariaLabel: "locations" }) %}
+      {{ govukTable({
+        caption: macro.tableCaption("locations", pagination.results.count, q) | safe,
+        captionClasses: "govuk-table__caption--m govuk-!-font-size-19 govuk-!-font-weight-regular",
+        head: [{
+          html: "Code"
+        }, {
+          text: "Postcode"
+        }, {
+          text: "Type of unit"
+        }, {
+          html: "Adapted"
+        }, {
+          text: "Actions"
+        } if isAdmin and not scheme.deactivated],
+        rows: locationRows
+      }) }}
+    {% endcall %}
+
+    {{ appPagination(pagination) }}
+  {% endif %}
 {% endblock %}

--- a/app/views/schemes/locations.njk
+++ b/app/views/schemes/locations.njk
@@ -19,9 +19,7 @@
     }, {
       html: macro.entityHtml(location.postcode, locationPath, location.name) if location.postcode else "Not known"
     }, {
-      text: location["type-of-unit"] | textFromInputValue(data.questions["type-of-unit"].supported)
-    }, {
-      text: location["is-adapted"] | textFromInputValue(data.questions["yes-no"])
+      html: macro.entityHtml(location["type-of-unit"] | textFromInputValue(data.questions["type-of-unit"].supported), false, "With wheelchair adaptations" if location["is-adapted"] == "true")
     }, {
       html: "<a href=\"" + locationPath + "/delete\">Delete<span class=\"govuk-visually-hidden\">" + location.postcode + "</span>" if isAdmin and not scheme.deactivated
     }])
@@ -48,8 +46,6 @@
           text: "Postcode"
         }, {
           text: "Type of unit"
-        }, {
-          html: "Adapted"
         }, {
           text: "Actions"
         } if isAdmin and not scheme.deactivated],

--- a/app/views/schemes/scheme.njk
+++ b/app/views/schemes/scheme.njk
@@ -3,5 +3,9 @@
 {% set section = "scheme" %}
 
 {% block sectionContent %}
-  {% include "schemes/_scheme-answers.njk" %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+      {% include "schemes/_scheme-answers.njk" %}
+    </div>
+  </div>
 {% endblock %}

--- a/scripts/generate-schemes.js
+++ b/scripts/generate-schemes.js
@@ -172,7 +172,7 @@ const generateSchemes = () => {
       ]),
       locations: generateLocations(faker.datatype.number({
         min: 1,
-        max: 9
+        max: 150
       }))
     }
 

--- a/scripts/generate-schemes.js
+++ b/scripts/generate-schemes.js
@@ -123,7 +123,10 @@ const generateSchemes = () => {
         const id = `l${i + 1}`
         locations[id] = {
           postcode: faker.address.zipCode(),
-          address: `${faker.helpers.arrayElement(streetNames)}, ${faker.address.city()}`,
+          name: `${faker.datatype.number({
+            min: 1,
+            max: 150
+          })} ${faker.helpers.arrayElement(streetNames)}`,
           'local-authority': faker.helpers.arrayElement(localAuthorities).name,
           'type-of-unit': faker.helpers.arrayElement([
             'bungalow',

--- a/scripts/generate-schemes.js
+++ b/scripts/generate-schemes.js
@@ -150,11 +150,11 @@ const generateSchemes = () => {
       deactivated: faker.datatype.boolean(),
       name,
       confidential: faker.datatype.boolean().toString(),
-      organisationId: value.organisationId,
+      ownerId: value.ownerId,
       agentId: faker.helpers.arrayElement([
         'AGENT',
         'OWNER_AGENT',
-        value.organisationId
+        value.ownerId
       ]),
       type,
       'registered-home': faker.helpers.arrayElement([


### PR DESCRIPTION
## Showing many locations with a scheme

We currently use a summary card interface to show the locations within a scheme. While this works for 10s of locations, it soon breaks down when there are hundreds. From exploring the dataset for existing schemes, 100s of locations within a scheme is likely to be the norm, rather than the exception.

We can use the pattern we have used elsewhere, and instead show locations in a table view, paginated, and with a search filter:

| Before | After |
| - | - |
| ![locations-before](https://user-images.githubusercontent.com/813383/175336940-744fdbab-8437-42e1-95ff-df771cc6cf79.png) | ![locations-after](https://user-images.githubusercontent.com/813383/175337342-052c2b5e-14a1-4a2e-a23d-b645a6418e04.png) |

## Allowing locations to include an optional name

Schemes in current CORE include useful location-related names. To help with the transition to the new model, and to help data inputters identify the correct location when creating a log, we can allow schemes to include an optional name. A location requires a postcode, which we will always be shown, but we can also display a name if one has been provided.

(We may want to consider changing how we show locations when selecting them during log submission… another autocomplete?)

| Editing name | Showing name |
| - | - |
| ![location-name](https://user-images.githubusercontent.com/813383/175337518-e413e3bd-0e3c-4b80-863d-6e752f0bdcba.png) | ![location-name-selection](https://user-images.githubusercontent.com/813383/175337482-94371a40-46ae-45f5-a2ed-2304186f9a2e.png) |

## Allowing support agents to change which organisation owns a scheme

We currently don’t show – or allow customer support agents to edit – the organisation that owns the housing stock that a scheme operates in. Much like we have recently done for individual logs, we can do the same here.

| Editing owner | Showing owner |
| - | - |
| ![scheme-owner](https://user-images.githubusercontent.com/813383/175337831-5206ae3f-5d06-48b2-8f69-bb7c5f4630c3.png) | ![scheme-details](https://user-images.githubusercontent.com/813383/175337794-195de803-29fd-4e31-8794-43e2b3eb8793.png) |