### PR TITLE
Add management type question to schemes

### DIFF
--- a/app/data/questions/arrangement.js
+++ b/app/data/questions/arrangement.js
@@ -1,0 +1,13 @@
+export default [{
+  text: 'Your organisation',
+  value: 'owner'
+}, {
+  text: 'Another registered housing provider',
+  value: 'agent'
+}, {
+  text: 'A registered charity or voluntary organisation',
+  value: 'charity'
+}, {
+  text: 'Another organisation',
+  value: 'other'
+}]

--- a/app/routes/schemes.js
+++ b/app/routes/schemes.js
@@ -7,7 +7,14 @@ const getSchemeWizardPaths = (req) => {
   const schemePath = `/schemes/${schemeId}/`
 
   const journey = {
-    [`${schemePath}details`]: {},
+    [`${schemePath}details`]: {
+      // SKIP: Don’t ask for agent if managed by owner
+      [`${schemePath}primary-client-group`]: {
+        data: `schemes.${schemeId}.arrangement`,
+        value: 'owner'
+      }
+    },
+    [`${schemePath}agent`]: {},
     [`${schemePath}primary-client-group`]: {},
     [`${schemePath}has-secondary-client-group`]: {
       // SKIP: Don’t ask for secondary client group if none needed
@@ -229,6 +236,7 @@ export const schemeRoutes = (router) => {
       res.render(`schemes/${view}`, {
         localAuthorities,
         organisations,
+        owner,
         owners,
         agents,
         itemId,

--- a/app/views/schemes/_scheme-details.njk
+++ b/app/views/schemes/_scheme-details.njk
@@ -32,28 +32,6 @@
     }) if not scheme.deactivated
   }, {
     key: {
-      text: "Housing stock owned by"
-    },
-    value: {
-      text: organisations[scheme.ownerId].name
-    },
-    actions: actionLinks({
-      href: schemePath + "/details-simple",
-      visuallyHiddenText: "who owns the housing stock for this scheme"
-    }) if not scheme.deactivated
-  } if isAdmin, {
-    key: {
-      text: "Managed by"
-    },
-    value: {
-      text: organisations[scheme.agentId].name
-    },
-    actions: actionLinks({
-      href: schemePath + "/details",
-      visuallyHiddenText: "who this scheme is managed by"
-    }) if not descoped
-  }, {
-    key: {
       text: "Type of scheme"
     },
     value: {
@@ -75,6 +53,39 @@
       visuallyHiddenText: "if scheme is a registered as a care home"
     }) if not descoped
   }, {
+    key: {
+      text: "Housing stock owned by"
+    },
+    value: {
+      text: organisations[scheme.ownerId].name
+    },
+    actions: actionLinks({
+      href: schemePath + "/details-simple",
+      visuallyHiddenText: "who owns the housing stock for this scheme"
+    }) if not scheme.deactivated
+  } if isAdmin, {
+    key: {
+      text: "Properties managed by"
+    },
+    value: {
+      text: scheme.arrangement | textFromInputValue(data.questions.arrangement)
+    },
+    actions: actionLinks({
+      href: schemePath + "/details",
+      visuallyHiddenText: "who manages this scheme"
+    }) if not descoped
+  }, {
+    key: {
+      text: "Managing organisation"
+    },
+    value: {
+      text: organisations[scheme.agentId].name
+    },
+    actions: actionLinks({
+      href: schemePath + "/agent",
+      visuallyHiddenText: "organisation that manages this scheme"
+    }) if not descoped
+  } if scheme.arrangement != "owner", {
     key: {
       text: "Primary client group"
     },

--- a/app/views/schemes/_scheme-details.njk
+++ b/app/views/schemes/_scheme-details.njk
@@ -65,7 +65,7 @@
     }) if not scheme.deactivated
   } if isAdmin, {
     key: {
-      text: "Properties managed by"
+      html: "Support services provided by" | noOrphans
     },
     value: {
       text: scheme.arrangement | textFromInputValue(data.questions.arrangement)
@@ -76,7 +76,7 @@
     }) if not descoped
   }, {
     key: {
-      text: "Managing organisation"
+      text: "Organisation providing support"
     },
     value: {
       text: organisations[scheme.agentId].name

--- a/app/views/schemes/agent.njk
+++ b/app/views/schemes/agent.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/question.njk" %}
 
-{% set title = "Which organisation manages the properties used by this scheme?" %}
+{% set title = "Which organisation provides the support services used by this scheme?" %}
 {% set caption = scheme.name %}
 {% set required = true %}
 

--- a/app/views/schemes/agent.njk
+++ b/app/views/schemes/agent.njk
@@ -1,0 +1,25 @@
+{% extends "layouts/question.njk" %}
+
+{% set title = "Which organisation manages the properties used by this scheme?" %}
+{% set caption = scheme.name %}
+{% set required = true %}
+
+{% if scheme.agentId %}
+  {# Editing an existing scheme #}
+  {% set buttonText = "Continue" %}
+  {% set formAction = schemePath + "/check-updated-answers" %}
+  {% set hasAnsweredQuestion = true %}
+{% endif %}
+
+{% block question %}
+  {# Ideally show radio options if number of organisations is less than 10 #}
+  {{ appAutocomplete(decorate({
+    label: {
+      classes: "govuk-label--l",
+      html: macro.heading(title, caption)
+    },
+    allowEmpty: true,
+    showNoOptionsFound: true,
+    items: agents | optionItems
+  }, ["schemes", scheme.id, "agentId"])) }}
+{% endblock %}

--- a/app/views/schemes/details-simple.njk
+++ b/app/views/schemes/details-simple.njk
@@ -1,12 +1,11 @@
 {% extends "layouts/question.njk" %}
 
-{% set required = true %}
-
 {# Editing an existing scheme, with limited editing options #}
 {% set caption = scheme.name %}
 {% set title = "Scheme details" %}
 {% set buttonText = "Continue" %}
 {% set formAction = schemePath + "/update" %}
+{% set required = true %}
 {% set hasAnsweredQuestion = true %}
 
 {% block question %}
@@ -36,22 +35,14 @@
     items: data.questions["yes-no"]
   }) }}
 
-  {% if isAdmin %}
-    {# Ideally show radio options if number of organisations is less than 10 #}
-    {{ appAutocomplete(decorate({
-      label: {
-        classes: "govuk-label--m",
-        html: "Which organisation owns the housing stock for this scheme?"
-      },
-      allowEmpty: true,
-      showNoOptionsFound: true,
-      items: owners | optionItems
-    }, ["schemes", scheme.id, "ownerId"])) }}
-  {% else %}
-    {{ govukInput({
-      decorate: ["schemes", scheme.id, "ownerId"],
-      value: scheme.ownerId,
-      type: "hidden"
-    }) }}
-  {% endif %}
+  {# Ideally show radio options if number of organisations is less than 10 #}
+  {{ appAutocomplete(decorate({
+    label: {
+      classes: "govuk-label--m",
+      html: "Which organisation owns the housing stock for this scheme?"
+    },
+    allowEmpty: true,
+    showNoOptionsFound: true,
+    items: owners | optionItems
+  }, ["schemes", scheme.id, "ownerId"])) if isAdmin }}
 {% endblock %}

--- a/app/views/schemes/details.njk
+++ b/app/views/schemes/details.njk
@@ -77,7 +77,7 @@
     fieldset: {
       legend: {
         classes: "govuk-fieldset__legend--m",
-        text: "Who manages the properties used by this scheme?"
+        text: "Who provides the support services used by this scheme?"
       }
     },
     items: [{

--- a/app/views/schemes/details.njk
+++ b/app/views/schemes/details.njk
@@ -39,36 +39,6 @@
     }]
   }) }}
 
-  {% if isAdmin %}
-    {# Ideally show radio options if number of organisations is less than 10 #}
-    {{ appAutocomplete(decorate({
-      label: {
-        classes: "govuk-label--m",
-        html: "Which organisation owns the housing stock for this scheme?"
-      },
-      allowEmpty: true,
-      showNoOptionsFound: true,
-      items: owners | optionItems
-    }, ["schemes", scheme.id, "ownerId"])) }}
-  {% else %}
-    {{ govukInput({
-      decorate: ["schemes", scheme.id, "ownerId"],
-      value: scheme.ownerId,
-      type: "hidden"
-    }) }}
-  {% endif %}
-
-  {# Ideally show radio options if number of organisations is less than 10 #}
-  {{ appAutocomplete(decorate({
-    label: {
-      classes: "govuk-label--m",
-      html: "Which organisation manages this scheme?"
-    },
-    allowEmpty: true,
-    showNoOptionsFound: true,
-    items: agents | optionItems
-  }, ["schemes", scheme.id, "agentId"])) }}
-
   {{ govukRadios({
     decorate: ["schemes", scheme.id, "type"],
     fieldset: {
@@ -89,5 +59,39 @@
       }
     },
     items: data.questions["registered-home"]
+  }) }}
+
+  {# Ideally show radio options if number of organisations is less than 10 #}
+  {{ appAutocomplete(decorate({
+    label: {
+      classes: "govuk-label--m",
+      html: "Which organisation owns the housing stock for this scheme?"
+    },
+    allowEmpty: true,
+    showNoOptionsFound: true,
+    items: agents | optionItems
+  }, ["schemes", scheme.id, "ownerId"])) if isAdmin }}
+
+  {{ govukRadios({
+    decorate: ["schemes", scheme.id, "arrangement"],
+    fieldset: {
+      legend: {
+        classes: "govuk-fieldset__legend--m",
+        text: "Who manages the properties used by this scheme?"
+      }
+    },
+    items: [{
+      text: "The same organisation that owns the housing stock",
+      value: "owner"
+    }, {
+      text: "Another registered housing provider",
+      value: "agent"
+    }, {
+      text: "A registered charity or voluntary organisation",
+      value: "charity"
+    }, {
+      text: "Another organisation",
+      value: "other"
+    }] if isAdmin else data.questions.arrangement
   }) }}
 {% endblock %}

--- a/scripts/generate-schemes.js
+++ b/scripts/generate-schemes.js
@@ -146,6 +146,18 @@ const generateSchemes = () => {
       return locations
     }
 
+    const arrangement = faker.helpers.arrayElement([
+      'owner',
+      'agent',
+      'charity',
+      'other'
+    ])
+
+    const ownerId = faker.helpers.arrayElement([
+      'OWNER',
+      'OWNER_AGENT'
+    ])
+
     // Scheme
     schemes[id] = {
       id,
@@ -153,14 +165,14 @@ const generateSchemes = () => {
       deactivated: faker.datatype.boolean(),
       name,
       confidential: faker.datatype.boolean().toString(),
-      ownerId: faker.helpers.arrayElement([
-        'OWNER',
-        'OWNER_AGENT'
-      ]),
-      agentId: faker.helpers.arrayElement([
-        'AGENT',
-        'OWNER_AGENT'
-      ]),
+      arrangement,
+      ownerId,
+      agentId: arrangement === 'owner'
+        ? ownerId
+        : faker.helpers.arrayElement([
+          'AGENT',
+          'OWNER_AGENT'
+        ]),
       type,
       'registered-home': faker.helpers.arrayElement([
         'nursing',


### PR DESCRIPTION
## For a data coordinator

1. When creating a new scheme, ask ‘Who provides the support services used by this scheme?’:

  <img width="575" alt="Screenshot 2022-07-06 at 13 04 29" src="https://user-images.githubusercontent.com/813383/177546031-d2f4be2b-6c78-4504-b6d5-82f6d6305670.png">

2. If the answer to this anything besides ‘Your organisation’, show a second question, ‘Which organisation provides the support services used by this scheme?’: 

  <img width="575" alt="Screenshot 2022-07-06 at 13 05 23" src="https://user-images.githubusercontent.com/813383/177546129-0f2dbde4-ee66-471a-85ad-948916d2d7f7.png">

3. When checking answers, only show ‘Organisation providing support’ if the user did not select ‘Your organisation’:

  <img width="645" alt="Screenshot 2022-07-06 at 13 06 36" src="https://user-images.githubusercontent.com/813383/177546354-de4ab488-30ce-4d42-8d79-4467f33f34aa.png">

4. The same applies to showing the scheme details page. Note that the order of values shown has changed from what we have currently:

  <img width="665" alt="Screenshot 2022-07-06 at 13 08 22" src="https://user-images.githubusercontent.com/813383/177546618-6100524d-ed9b-4498-aa89-3a86fd7c57f6.png">

5. If an organisation manages its properties in the scheme, don’t show the ‘Organisation providing support’ row:

  <img width="660" alt="Screenshot 2022-07-06 at 13 09 24" src="https://user-images.githubusercontent.com/813383/177546777-9744ef58-fa51-4402-9559-18160bb773a1.png">

## For a support agent

* For a support agent adding a scheme, in addition to asking for the organisation that owns the properties, the text for the question of who provides support changes from ‘Your organisation’ to ‘The same organisation that owns the housing stock’.

  <img width="645" alt="Screenshot 2022-07-06 at 13 02 29" src="https://user-images.githubusercontent.com/813383/177545657-9f6f151d-6d59-4e66-a4e7-0fd10c57cfa9.png">
