### PR TITLE
Better behaviour on autocomplete button

### DIFF
--- a/app/components/autocomplete/autocomplete.js
+++ b/app/components/autocomplete/autocomplete.js
@@ -49,14 +49,20 @@ export const setupAutoComplete = ($module) => {
     },
     templates: { suggestion: (value) => suggestion(value, options) },
     onConfirm: (val) => {
-      enableDependentButtons()
-
       const selectedOption = [].filter.call(
         selectOptions,
         (option) => (option.textContent || option.innerText) === val
       )[0]
 
-      if (selectedOption) selectedOption.selected = true
+      if (selectedOption) {
+        selectedOption.selected = true
+      }
+
+      if (selectOptions.some((option) => option.selected && option.value)) {
+        enableDependentButtons()
+      } else {
+        disableDependentButtons()
+      }
     }
   })
 

--- a/scripts/generate-logs.js
+++ b/scripts/generate-logs.js
@@ -57,8 +57,10 @@ const generateLogs = () => {
           'Social Rent'
         ]),
         'letting-start-date': faker.date.past(2),
-        'tenant-code': faker.datatype.hexadecimal(8).toUpperCase(),
-        'property-reference': faker.datatype.hexadecimal(8).toUpperCase(),
+        'tenant-code': faker.datatype.hexadecimal({ length: 8 }).toUpperCase(),
+        'property-reference': faker.datatype
+          .hexadecimal({ length: 8 })
+          .toUpperCase(),
         completed: 'true'
       },
       'household-characteristics': {


### PR DESCRIPTION
Still not perfect.

If you:
- Search for + select an actual value (A)
- Then replace the contents of the box with a value not in the list (B)
Then the button will remain enabled, and when clicked the notification banner will say you have added B, but your list of agents will actually contain A.

But that aside, otherwise the behaviour is better.